### PR TITLE
Format include param to LinkedEvents event endpoint

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -256,7 +256,7 @@ class Query:
     @staticmethod
     def resolve_event(parent, info, **kwargs):
         if kwargs.get("include"):
-            params = {"include": kwargs["include"]}
+            params = {"include": ",".join(kwargs["include"])}
             response = api_client.retrieve("event", kwargs["id"], params=params)
         else:
             response = api_client.retrieve("event", kwargs["id"])


### PR DESCRIPTION
At the moment when trying to get event with include param only the last string of the array is effective. 
 
For example: When trying to get event with include param ["keyword", "audience"] -> only audience object is opened.
  