### PR TITLE
PT-230 | Only return linked events created by palvelutarjotin

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -23,6 +23,7 @@ from occurrences.schema import PalvelutarjotinEventInput, PalvelutarjotinEventNo
 from common.utils import update_object
 from palvelutarjotin import settings
 from palvelutarjotin.exceptions import ObjectDoesNotExistError
+from palvelutarjotin.settings import LINKED_EVENTS_API_CONFIG
 
 api_client = LinkedEventsApiClient(config=settings.LINKED_EVENTS_API_CONFIG)
 
@@ -275,6 +276,9 @@ class Query:
 
     @staticmethod
     def resolve_events(parent, info, **kwargs):
+        # FIXME: Only return events belongs to user organisation
+        # Filter events created from palvelutarjotin
+        kwargs["data_source"] = LINKED_EVENTS_API_CONFIG["DATA_SOURCE"]
         response = api_client.list("event", filter_list=kwargs)
         return json2obj(format_response(response))
 

--- a/palvelutarjotin/settings.py
+++ b/palvelutarjotin/settings.py
@@ -57,6 +57,7 @@ env = environ.Env(
     ENABLE_GRAPHIQL=(bool, False),
     LINKED_EVENTS_API_ROOT=(str, "https://api.hel.fi/linkedevents/v1/"),
     LINKED_EVENTS_API_KEY=(str, ""),
+    LINKED_EVENTS_DATA_SOURCE=(str, "palvelutarjotin"),
 )
 
 if os.path.exists(env_file):
@@ -219,6 +220,7 @@ PALVELUTARJOTIN_QUERY_MAX_DEPTH = 12
 LINKED_EVENTS_API_CONFIG = {
     "ROOT": env.str("LINKED_EVENTS_API_ROOT"),
     "API_KEY": env.str("LINKED_EVENTS_API_KEY"),
+    "DATA_SOURCE": env.str("LINKED_EVENTS_DATA_SOURCE"),
 }
 
 AXES_FAILURE_LIMIT = 5


### PR DESCRIPTION
Ideally the events endpoint should return events from logged in provider organisation. However it's not easy to do so with our current architecture (shared API key between provider account). In order to do that will require provider to authenticate both Palvelutarjotin in LinkedEvent which is not a good UX atm. So we decided to just restrict the events query to return only event with `data_source=palvelutarjotin`  