### PR TITLE
PT-267, PT-275 | Add organisation id to add/update event mutation

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -2,10 +2,15 @@ from datetime import datetime
 
 from django.db import transaction
 from django.utils import timezone
+from graphene import Node
 from graphql_relay import from_global_id
 
 from palvelutarjotin import __version__
-from palvelutarjotin.exceptions import DataValidationError, IncorrectGlobalIdError
+from palvelutarjotin.exceptions import (
+    DataValidationError,
+    IncorrectGlobalIdError,
+    ObjectDoesNotExistError,
+)
 from palvelutarjotin.settings import REVISION
 
 
@@ -45,3 +50,12 @@ def convert_to_localtime_tz(value):
         return timezone.make_aware(dt).timetz()
     else:
         return timezone.localtime(dt).timetz()
+
+
+def get_obj_from_global_id(info, global_id, expected_obj_type):
+    obj = Node.get_node_from_global_id(info, global_id)
+    if not obj or type(obj) != expected_obj_type:
+        raise ObjectDoesNotExistError(
+            f"{expected_obj_type.__name__} matching query does not exist."
+        )
+    return obj

--- a/graphene_linked_events/tests/test_api.py
+++ b/graphene_linked_events/tests/test_api.py
@@ -14,8 +14,8 @@ def autouse_db(db):
 
 
 GET_EVENTS_QUERY = """
-query Events{
-  events{
+query Events($organisationId: String){
+  events(organisationId: $organisationId){
     meta {
       count
       next
@@ -552,8 +552,13 @@ query eventsSearch{
 """
 
 
-def test_get_events(api_client, snapshot, mock_get_events_data):
-    executed = api_client.execute(GET_EVENTS_QUERY)
+def test_get_events(api_client, snapshot, mock_get_events_data, organisation):
+    # Because of mock data, this test might not return correct result,
+    # but the goal is to test if organisation argument work in `resolve_events`
+    executed = api_client.execute(
+        GET_EVENTS_QUERY,
+        variables={"organisationId": to_global_id("OrganisationNode", organisation.id)},
+    )
     snapshot.assert_match(executed)
 
 

--- a/graphene_linked_events/tests/test_api.py
+++ b/graphene_linked_events/tests/test_api.py
@@ -1,4 +1,7 @@
+from copy import deepcopy
+
 import pytest
+from graphql_relay import to_global_id
 from occurrences.factories import PalvelutarjotinEventFactory
 from occurrences.models import PalvelutarjotinEvent
 
@@ -636,6 +639,7 @@ mutation addEvent($input: AddEventMutationInput!){
 
 CREATE_EVENT_VARIABLES = {
     "input": {
+        "organisationId": "",
         "pEvent": {
             "enrolmentStart": "2020-06-06T16:40:48+00:00",
             "enrolmentEndDays": 2,
@@ -679,10 +683,12 @@ def test_create_event_unauthorized(api_client, user_api_client):
     assert_permission_denied(executed)
 
 
-def test_create_event(staff_api_client, snapshot, mock_create_event_data):
-    executed = staff_api_client.execute(
-        CREATE_EVENT_MUTATION, variables=CREATE_EVENT_VARIABLES
+def test_create_event(staff_api_client, snapshot, mock_create_event_data, organisation):
+    variables = deepcopy(CREATE_EVENT_VARIABLES)
+    variables["input"]["organisationId"] = to_global_id(
+        "OrganisationNode", organisation.id
     )
+    executed = staff_api_client.execute(CREATE_EVENT_MUTATION, variables=variables)
     assert PalvelutarjotinEvent.objects.count() == 1
     snapshot.assert_match(executed)
 
@@ -735,6 +741,7 @@ mutation addEvent($input: UpdateEventMutationInput!){
 UPDATE_EVENT_VARIABLES = {
     "input": {
         "id": "qq:afy6aghr2y",
+        "organisationId": "",
         "pEvent": {
             "enrolmentStart": "2020-06-06T16:40:48+00:00",
             "enrolmentEndDays": 2,
@@ -778,12 +785,14 @@ def test_update_event_unauthorized(api_client, user_api_client):
     assert_permission_denied(executed)
 
 
-def test_update_event(staff_api_client, snapshot, mock_update_event_data):
+def test_update_event(staff_api_client, snapshot, mock_update_event_data, organisation):
+    variables = deepcopy(UPDATE_EVENT_VARIABLES)
+    variables["input"]["organisationId"] = to_global_id(
+        "OrganisationNode", organisation.id
+    )
     PalvelutarjotinEventFactory(linked_event_id=UPDATE_EVENT_VARIABLES["input"]["id"],)
 
-    executed = staff_api_client.execute(
-        UPDATE_EVENT_MUTATION, variables=UPDATE_EVENT_VARIABLES
-    )
+    executed = staff_api_client.execute(UPDATE_EVENT_MUTATION, variables=variables)
     snapshot.assert_match(executed)
 
 

--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -21,7 +21,7 @@ class PalvelutarjotinEvent(TimestampedModel):
     )
     duration = models.PositiveSmallIntegerField(verbose_name=_("duration"))
     needed_occurrences = models.PositiveSmallIntegerField(
-        verbose_name=_("needed " "occurrence"), default=1
+        verbose_name=_("needed occurrence"), default=1
     )
 
     class Meta:


### PR DESCRIPTION
`publisher` is a sub-organisation id created in linkedEvent which is now editable from API.

Publisher doesn’t not need to be provided through graphql argument but might be decided by user organisation selection since organsation has `publisher_id`

This field will be later used in events list filter to show events from user organisation only

Validation & authorization is out of the scope of this PR and will be implement later in a separated PR