### PR TITLE
PT-294 | Use APIKEY header in get query if user is staff, added showAll argument

### DIFF
--- a/graphene_linked_events/rest_client.py
+++ b/graphene_linked_events/rest_client.py
@@ -19,24 +19,41 @@ class LinkedEventsApiClient(object):
             "upload": {"method": "POST", "url": url + "/"},
         }
 
-    def retrieve(self, resource, id, params=None):
+    def retrieve(self, resource, id, params=None, is_staff=False):
         actions = self.get_actions(resource)
+
+        if is_staff:
+            headers = {"apikey": self.api_key}
+            return requests.request(
+                actions["retrieve"]["method"],
+                actions["retrieve"]["url"].format(id),
+                params=params,
+                headers=headers,
+            )
         return requests.request(
             actions["retrieve"]["method"],
             actions["retrieve"]["url"].format(id),
             params=params,
         )
 
-    def list(self, resource, filter_list=None):
+    def list(self, resource, filter_list=None, is_staff=False):
         actions = self.get_actions(resource)
         filter_params = filter_list
+        if is_staff:
+            headers = {"apikey": self.api_key}
+            return requests.request(
+                actions["list"]["method"],
+                actions["list"]["url"],
+                params=filter_params,
+                headers=headers,
+            )
         return requests.request(
             actions["list"]["method"], actions["list"]["url"], params=filter_params
         )
 
     def create(self, resource, body):
         actions = self.get_actions(resource)
-        headers = {"apikey": self.api_key, "Content-Type": "application/json"}
+        headers = {"apikey": self.api_key}
         return requests.request(
             actions["create"]["method"],
             actions["create"]["url"],
@@ -46,7 +63,7 @@ class LinkedEventsApiClient(object):
 
     def update(self, resource, id, body):
         actions = self.get_actions(resource)
-        headers = {"apikey": self.api_key, "Content-Type": "application/json"}
+        headers = {"apikey": self.api_key}
         return requests.request(
             actions["update"]["method"],
             actions["update"]["url"].format(id),
@@ -56,7 +73,7 @@ class LinkedEventsApiClient(object):
 
     def delete(self, resource, id):
         actions = self.get_actions(resource)
-        headers = {"apikey": self.api_key, "Content-Type": "application/json"}
+        headers = {"apikey": self.api_key}
         return requests.request(
             actions["delete"]["method"],
             actions["delete"]["url"].format(id),

--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -249,6 +249,8 @@ class Query:
         text=String(),
         translation=String(),
         organisation_id=String(),
+        show_all=Boolean(),
+        publication_status=String(),
     )
     event = Field(Event, id=ID(required=True), include=List(String))
 
@@ -291,9 +293,16 @@ class Query:
     def resolve_event(parent, info, **kwargs):
         if kwargs.get("include"):
             params = {"include": ",".join(kwargs["include"])}
-            response = api_client.retrieve("event", kwargs["id"], params=params)
+            response = api_client.retrieve(
+                "event",
+                kwargs["id"],
+                params=params,
+                is_staff=info.context.user.is_staff,
+            )
         else:
-            response = api_client.retrieve("event", kwargs["id"])
+            response = api_client.retrieve(
+                "event", kwargs["id"], is_staff=info.context.user.is_staff
+            )
         obj = json2obj(format_response(response))
         return obj
 
@@ -310,7 +319,9 @@ class Query:
             # If no organisation id specified, return all events from
             # palvelutarjotin data source
             kwargs["data_source"] = LINKED_EVENTS_API_CONFIG["DATA_SOURCE"]
-        response = api_client.list("event", filter_list=kwargs)
+        response = api_client.list(
+            "event", filter_list=kwargs, is_staff=info.context.user.is_staff
+        )
         return json2obj(format_response(response))
 
     @staticmethod


### PR DESCRIPTION
If user is staff, an authentication header will be added so user can be able to query draft events
Also added `showAll` argument to the query parameter to make draft events visible, and `publicationStatus` to filter event by `publication_status`