### PR TITLE
PT-377 | Sent notification to enrolment-contact-person if possible

### DIFF
--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -311,6 +311,7 @@ class Enrolment(models.Model):
     def approve(self, custom_message=None):
         self.set_status(self.STATUS_APPROVED)
         send_event_notifications_to_contact_person(
+            self.person,
             self.occurrence,
             self.study_group,
             self.notification_type,
@@ -323,6 +324,7 @@ class Enrolment(models.Model):
     def decline(self, custom_message=None):
         self.set_status(self.STATUS_DECLINED)
         send_event_notifications_to_contact_person(
+            self.person,
             self.occurrence,
             self.study_group,
             self.notification_type,

--- a/occurrences/signals.py
+++ b/occurrences/signals.py
@@ -10,6 +10,7 @@ from occurrences.utils import send_event_notifications_to_contact_person
 def send_enrolment_email(instance, created, **kwargs):
     if created:
         send_event_notifications_to_contact_person(
+            instance.person,
             instance.occurrence,
             instance.study_group,
             instance.notification_type,
@@ -22,6 +23,7 @@ def send_enrolment_email(instance, created, **kwargs):
 @receiver(post_delete, sender=Enrolment, dispatch_uid="send_unenrolment_email")
 def send_unenrolment_email(instance, **kwargs):
     send_event_notifications_to_contact_person(
+        instance.person,
         instance.occurrence,
         instance.study_group,
         instance.notification_type,

--- a/occurrences/tests/snapshots/snap_test_notifications.py
+++ b/occurrences/tests/snapshots/snap_test_notifications.py
@@ -54,3 +54,30 @@ snapshots["test_decline_enrolment_notification_email 1"] = [
         Custom message: custom message
 """
 ]
+
+snapshots["test_occurrence_enrolment_notifications_to_contact_person 1"] = [
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence enrolment FI|
+        Event FI: Raija Malka & Kaija Saariaho: Blick
+        Extra event info: Leg him president compare room hotel town.
+        Study group: Senior number scene today friend maintain marriage.
+        Occurrence: 2013-12-12 06:37:19+01:40
+        Person: stacey98@wolfe.com""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence unenrolment FI|
+        Event FI: Raija Malka & Kaija Saariaho: Blick
+        Extra event info: Leg him president compare room hotel town.
+        Study group: Senior number scene today friend maintain marriage.
+        Occurrence: 2013-12-12 04:57:19+00:00
+        Person: stacey98@wolfe.com""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence enrolment EN|
+        Event EN: Raija Malka & Kaija Saariaho: Blick
+        Extra event info: Leg him president compare room hotel town.
+        Study group: Hot identify each its general. By garden so country past involve choose.
+        Occurrence: 2013-12-12 06:37:19+01:40
+        Person: do_not_email_me@domain.com""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence unenrolment EN|
+        Event EN: Raija Malka & Kaija Saariaho: Blick
+        Extra event info: Leg him president compare room hotel town.
+        Study group: Hot identify each its general. By garden so country past involve choose.
+        Occurrence: 2013-12-12 04:57:19+00:00
+        Person: do_not_email_me@domain.com""",
+]

--- a/occurrences/utils.py
+++ b/occurrences/utils.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def send_event_notifications_to_contact_person(
+    person,
     occurrence,
     study_group,
     notification_type,
@@ -25,6 +26,8 @@ def send_event_notifications_to_contact_person(
     notification_sms_template_id,
     **kwargs,
 ):
+    if not person:
+        person = study_group.person
     if NOTIFICATION_TYPE_EMAIL in notification_type:
         context = {
             "occurrence": occurrence,
@@ -33,7 +36,7 @@ def send_event_notifications_to_contact_person(
         }
         # TODO: Send notification based on user language
         send_notification(
-            study_group.person.email_address,
+            person.email_address,
             notification_template_id,
             language=study_group.person.language,
             context=context,
@@ -45,7 +48,7 @@ def send_event_notifications_to_contact_person(
             **kwargs,
         }
         destinations = [
-            study_group.person.phone_number,
+            person.phone_number,
         ]
         send_sms_notification(
             destinations,


### PR DESCRIPTION
Previously notification was sent to study group contact person. But now since enrolment itself has a contact-person, notification should be sent to this person instead of of study group contact person (though most of the time they are the same person). Only use study_group.person if enrolment person is not available (backward compatible)