### PR TITLE
PT-384 | Mass approve enrolment

### DIFF
--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -523,7 +523,15 @@ class ApproveEnrolmentMutation(graphene.relay.ClientIDMutation):
             info, kwargs["enrolment_id"], Enrolment
         )
         custom_message = kwargs.pop("custom_message", None)
-        enrolment.approve(custom_message=custom_message)
+
+        # Need to approve all related occurrences of the study group
+        enrolments = Enrolment.objects.filter(
+            occurrence__p_event=enrolment.occurrence.p_event,
+            study_group=enrolment.study_group,
+        )
+        for e in enrolments:
+            e.approve(custom_message=custom_message)
+        enrolment.refresh_from_db()
         return ApproveEnrolmentMutation(enrolment=enrolment)
 
 

--- a/occurrences/tests/snapshots/snap_test_api.py
+++ b/occurrences/tests/snapshots/snap_test_api.py
@@ -750,11 +750,18 @@ snapshots["test_approve_enrolment_with_custom_message 2"] = [
 snapshots["test_approve_enrolment 2"] = [
     """no-reply@hel.ninja|['barbarafarrell@yahoo.com']|Enrolment approved FI|
         Event FI: Raija Malka & Kaija Saariaho: Blick
-        Extra event info: Plant traditional after born.
+        Extra event info: Anyone during approach herself remember put list.
         Study group: Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
         Occurrence: 2020-01-06 00:00:00+00:00
         Person: barbarafarrell@yahoo.com
-"""
+""",
+    """no-reply@hel.ninja|['barbarafarrell@yahoo.com']|Enrolment approved FI|
+        Event FI: Raija Malka & Kaija Saariaho: Blick
+        Extra event info: Anyone during approach herself remember put list.
+        Study group: Last appear experience seven. Throw wrong party wall agency customer clear. Control as receive cup.
+        Occurrence: 2020-01-06 00:00:00+00:00
+        Person: barbarafarrell@yahoo.com
+""",
 ]
 
 snapshots["test_decline_enrolment 2"] = [

--- a/occurrences/tests/test_api.py
+++ b/occurrences/tests/test_api.py
@@ -1163,10 +1163,12 @@ def test_approve_enrolment(
     notification_template_enrolment_approved_fi,
 ):
     study_group_15 = StudyGroupFactory(group_size=15)
+    study_group_10 = StudyGroupFactory(group_size=10)
     # Current date froze on 2020-01-04:
     p_event_1 = PalvelutarjotinEventFactory(
         enrolment_start=datetime(2020, 1, 3, 0, 0, 0, tzinfo=timezone.now().tzinfo),
         enrolment_end_days=2,
+        needed_occurrences=2,
     )
     occurrence = OccurrenceFactory(
         start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
@@ -1176,17 +1178,37 @@ def test_approve_enrolment(
         amount_of_seats=50,
         auto_acceptance=False,
     )
+    occurrence_2 = OccurrenceFactory(
+        start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
+        p_event=p_event_1,
+        min_group_size=10,
+        max_group_size=20,
+        amount_of_seats=50,
+        auto_acceptance=False,
+    )
     occurrence.study_groups.add(study_group_15)
-    assert occurrence.study_groups.count() == 1
     enrolment = occurrence.enrolments.first()
+    occurrence_2.study_groups.add(study_group_15)
+    occurrence.study_groups.add(study_group_10)
+    occurrence_2.study_groups.add(study_group_10)
+
+    assert occurrence.study_groups.count() == 2
+    assert occurrence_2.study_groups.count() == 2
     assert enrolment.status == Enrolment.STATUS_PENDING
 
     variables = {"input": {"enrolmentId": to_global_id("EnrolmentNode", enrolment.id)}}
     staff_api_client.user.person.organisations.add(occurrence.p_event.organisation)
     executed = staff_api_client.execute(APPROVE_ENROLMENT_MUTATION, variables=variables)
     snapshot.assert_match(executed)
-    assert len(mail.outbox) == 1
+    assert len(mail.outbox) == 2
     assert_mails_match_snapshot(snapshot)
+    for e in study_group_15.enrolments.all():
+        # Check if related enrolments change
+        assert e.status == Enrolment.STATUS_APPROVED
+    for e in study_group_10.enrolments.all():
+        # Check if unrelated enrolments do not change
+        assert e.status == Enrolment.STATUS_PENDING
+
     executed = staff_api_client.execute(APPROVE_ENROLMENT_MUTATION, variables=variables)
     assert_match_error_code(executed, API_USAGE_ERROR)
 
@@ -1278,7 +1300,7 @@ def test_decline_enrolment(
     assert len(mail.outbox) == 2
     assert_mails_match_snapshot(snapshot)
     for e in study_group_15.enrolments.all():
-        # Check if related enrolments do not change
+        # Check if related enrolments change
         assert e.status == Enrolment.STATUS_DECLINED
     for e in study_group_10.enrolments.all():
         # Check if unrelated enrolments do not change


### PR DESCRIPTION
When approving a single enrolment, if this is a multl-occurrences event, all related enrolments of that study group to the same event should be approved as well