### PR TITLE
Fix publication status query

### DIFF
--- a/graphene_linked_events/utils.py
+++ b/graphene_linked_events/utils.py
@@ -27,6 +27,8 @@ def format_request(request):
     return json.dumps(request).replace("internal_", "@")
 
 
-def retrieve_linked_events_data(resource, resource_id, params=None):
-    response = api_client.retrieve(resource, resource_id, params=params)
+def retrieve_linked_events_data(resource, resource_id, params=None, is_staff=False):
+    response = api_client.retrieve(
+        resource, resource_id, params=params, is_staff=is_staff
+    )
     return json2obj(format_response(response))

--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -69,10 +69,12 @@ class PalvelutarjotinEvent(TimestampedModel):
     def __str__(self):
         return f"{self.id} {self.linked_event_id}"
 
-    def get_event_data(self):
+    def get_event_data(self, is_staff=False):
         # We need query event location as well
         params = {"include": "location"}
-        return retrieve_linked_events_data("event", self.linked_event_id, params=params)
+        return retrieve_linked_events_data(
+            "event", self.linked_event_id, params=params, is_staff=is_staff
+        )
 
     def is_editable_by_user(self, user):
         if self.organisation:
@@ -81,7 +83,7 @@ class PalvelutarjotinEvent(TimestampedModel):
 
     def is_published(self):
         return (
-            self.get_event_data().publication_status
+            self.get_event_data(is_staff=True).publication_status
             == PalvelutarjotinEvent.PUBLICATION_STATUS_PUBLIC
         )
 


### PR DESCRIPTION
LinkedEvent API will return 404 for draft event if the query is from anonymous user so we would never get `publication_status` if it's a draft event.
Added an `is_staff` parameter to `get_event_data()` so when we want to get the `publication_status` we can use `is_staff` to always get the desired result.