### PR TITLE
PT-580 | Add categories and additional_criterial to event

### DIFF
--- a/graphene_linked_events/tests/mock_data.py
+++ b/graphene_linked_events/tests/mock_data.py
@@ -322,10 +322,22 @@ EVENT_DATA = {
         "@type": "Place",
     },
     "keywords": [
-        {"@id": "https://api.hel.fi/linkedevents/v1/keyword/helfi:12/"},
-        {"@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p5121/"},
-        {"@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p6889/"},
-        {"@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p1808/"},
+        {
+            "@id": "https://api.hel.fi/linkedevents/v1/keyword/helfi:12/",
+            "id": "helfi:12",
+        },
+        {
+            "@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p5121/",
+            "id": "yso:p5121",
+        },
+        {
+            "@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p6889/",
+            "id": "yso:p6889",
+        },
+        {
+            "@id": "https://api.hel.fi/linkedevents/v1/keyword/yso:p1808/",
+            "id": "yso:p1808",
+        },
     ],
     "super_event": None,
     "event_status": "EventPostponed",
@@ -983,10 +995,10 @@ RECAPTCHA_DATA = {
 }
 
 KEYWORD_SET_DATA = {
-    "id": "qq:kultus:categories",
+    "id": "kultus:categories",
     "keywords": [
         {
-            "id": "yso:p27033",
+            "id": "helfi:12",
             "alt_labels": ["vändagen", "Valentindagen"],
             "created_time": "2020-05-04T08:51:38.338194Z",
             "last_modified_time": "2020-05-04T08:51:38.338221Z",

--- a/graphene_linked_events/tests/snapshots/snap_test_api.py
+++ b/graphene_linked_events/tests/snapshots/snap_test_api.py
@@ -178,9 +178,11 @@ snapshots["test_get_events 1"] = {
 snapshots["test_get_event 1"] = {
     "data": {
         "event": {
+            "additionalCriteria": [{"id": "helfi:12"}],
             "audience": [],
             "audienceMaxAge": None,
             "audienceMinAge": None,
+            "categories": [{"id": "helfi:12"}],
             "createdTime": "2019-12-13T12:49:40.545273Z",
             "customData": None,
             "dataSource": "helsinki",
@@ -948,11 +950,11 @@ snapshots["test_unpublish_event 1"] = {
 snapshots["test_get_keyword_set 1"] = {
     "data": {
         "keywordSet": {
-            "id": "qq:kultus:categories",
+            "id": "kultus:categories",
             "internalId": "http://localhost:8080/v1/keyword_set/qq:kultus:categories/",
             "keywords": [
                 {
-                    "id": "yso:p27033",
+                    "id": "helfi:12",
                     "internalId": "http://localhost:8080/v1/keyword/yso:p27033/",
                     "name": {
                         "en": "Valentine's Day",
@@ -968,11 +970,11 @@ snapshots["test_get_keyword_set 1"] = {
 snapshots["test_get_keyword_set 2"] = {
     "data": {
         "keywordSet": {
-            "id": "qq:kultus:categories",
+            "id": "kultus:categories",
             "internalId": "http://localhost:8080/v1/keyword_set/qq:kultus:categories/",
             "keywords": [
                 {
-                    "id": "yso:p27033",
+                    "id": "helfi:12",
                     "internalId": "http://localhost:8080/v1/keyword/yso:p27033/",
                     "name": {
                         "en": "Valentine's Day",
@@ -988,11 +990,11 @@ snapshots["test_get_keyword_set 2"] = {
 snapshots["test_get_keyword_set 3"] = {
     "data": {
         "keywordSet": {
-            "id": "qq:kultus:categories",
+            "id": "kultus:categories",
             "internalId": "http://localhost:8080/v1/keyword_set/qq:kultus:categories/",
             "keywords": [
                 {
-                    "id": "yso:p27033",
+                    "id": "helfi:12",
                     "internalId": "http://localhost:8080/v1/keyword/yso:p27033/",
                     "name": {
                         "en": "Valentine's Day",

--- a/graphene_linked_events/utils.py
+++ b/graphene_linked_events/utils.py
@@ -32,3 +32,8 @@ def retrieve_linked_events_data(resource, resource_id, params=None, is_staff=Fal
         resource, resource_id, params=params, is_staff=is_staff
     )
     return json2obj(format_response(response))
+
+
+def get_keyword_set_by_id(keyword_set_id):
+    params = {"include": "keywords"}
+    return retrieve_linked_events_data("keyword_set", keyword_set_id, params=params,)


### PR DESCRIPTION

<img width="1009" alt="Screenshot 2020-11-05 at 9 19 56" src="https://user-images.githubusercontent.com/1481118/98361560-6e8c2a80-2034-11eb-9a09-27dc6dd3a31a.png">

UI has a need of knowing which keyword set a keyword belongs to in order to assign it to correct box in edit event page.
We need seperated fields in the event query to do so.
- For keywords of TARGET_GROUPS keyword set => already assigned in native linked event field `audiences`
- For keywords of CATEGORIES keyword set => assign to our `categories` field
- For keywords of ADDITIONAL_CRITERIA keyword set => assign to our `additional_criteria` field