### PR TITLE
Occurrence mutation should validate the start time against enrolment

### DIFF
--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -202,7 +202,7 @@ class OccurrenceNode(DjangoObjectType):
         return self.amount_of_seats - self.seats_taken
 
 
-def validate_occurrence_data(kwargs, updated_obj=None):
+def validate_occurrence_data(p_event, kwargs, updated_obj=None):
     end_time = (
         kwargs.get("end_time", updated_obj.end_time)
         if updated_obj
@@ -215,6 +215,13 @@ def validate_occurrence_data(kwargs, updated_obj=None):
     )
     if end_time <= start_time:
         raise DataValidationError("End time must be after start time")
+    minimum_time = (
+        (p_event.enrolment_start + timedelta(days=p_event.enrolment_end_days))
+        if p_event.enrolment_end_days
+        else p_event.enrolment_start
+    )
+    if start_time < minimum_time:
+        raise DataValidationError("Start time cannot be before the enrolment ends")
 
 
 @transaction.atomic
@@ -262,12 +269,12 @@ class AddOccurrenceMutation(graphene.relay.ClientIDMutation):
     @staff_member_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        validate_occurrence_data(kwargs)
-        contact_persons = kwargs.pop("contact_persons", None)
-        languages = kwargs.pop("languages", None)
         p_event = get_editable_obj_from_global_id(
             info, kwargs["p_event_id"], PalvelutarjotinEvent
         )
+        validate_occurrence_data(p_event, kwargs)
+        contact_persons = kwargs.pop("contact_persons", None)
+        languages = kwargs.pop("languages", None)
         if p_event.is_published():
             raise ApiUsageError("Cannot add occurrence to published event")
         kwargs["p_event_id"] = p_event.id
@@ -312,10 +319,10 @@ class UpdateOccurrenceMutation(graphene.relay.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **kwargs):
         occurrence = get_editable_obj_from_global_id(info, kwargs.pop("id"), Occurrence)
-        validate_occurrence_data(kwargs, occurrence)
+        p_event = occurrence.p_event
+        validate_occurrence_data(p_event, kwargs, occurrence)
         contact_persons = kwargs.pop("contact_persons", None)
         languages = kwargs.pop("languages", None)
-        p_event = occurrence.p_event
         if kwargs.get("p_event_id"):
             p_event = get_editable_obj_from_global_id(
                 info, kwargs["p_event_id"], PalvelutarjotinEvent

--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -920,7 +920,7 @@ class Query:
             return None
         qs = Enrolment.objects.filter(occurrence__p_event__organisation=organisation)
         if kwargs.get("status"):
-            qs = qs.filter(status=kwargs["status"])
+            qs = qs.filter(status=kwargs["status"]).order_by("status")
         return qs
 
 

--- a/occurrences/tests/snapshots/snap_test_notifications.py
+++ b/occurrences/tests/snapshots/snap_test_notifications.py
@@ -143,9 +143,9 @@ snapshots["test_send_enrolment_summary_report 1"] = [
             Event name: Raija Malka & Kaija Saariaho: Blick
             Event link: https://provider.kultus.fi/fi/events/aAVEa
                     Occurrence: #1996-02-20 13:49:25+00:00 (3 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6OTg=
-                    Occurrence: #2001-02-23 20:07:07+00:00 (1 pending)
                     Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6OTk=
+                    Occurrence: #2001-02-23 20:07:07+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTAw
         """,
     """no-reply@hel.ninja|['jgray@yahoo.com']|Enrolment approved FI|
         Total pending enrolments: 3
@@ -153,17 +153,17 @@ snapshots["test_send_enrolment_summary_report 1"] = [
             Event name: Raija Malka & Kaija Saariaho: Blick
             Event link: https://provider.kultus.fi/fi/events/SLZLM
                     Occurrence: #2017-06-11 11:22:16+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/SLZLM/occurrences/T2NjdXJyZW5jZU5vZGU6MTAx
-                    Occurrence: #1985-06-24 16:15:35+00:00 (1 pending)
                     Link to occurrence: https://provider.kultus.fi/fi/events/SLZLM/occurrences/T2NjdXJyZW5jZU5vZGU6MTAy
+                    Occurrence: #1985-06-24 16:15:35+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/SLZLM/occurrences/T2NjdXJyZW5jZU5vZGU6MTAz
             Event name: Raija Malka & Kaija Saariaho: Blick
             Event link: https://provider.kultus.fi/fi/events/Gqqvl
                     Occurrence: #1992-03-09 01:25:06+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/Gqqvl/occurrences/T2NjdXJyZW5jZU5vZGU6MTAz
+                    Link to occurrence: https://provider.kultus.fi/fi/events/Gqqvl/occurrences/T2NjdXJyZW5jZU5vZGU6MTA0
             Event name: Raija Malka & Kaija Saariaho: Blick
             Event link: https://provider.kultus.fi/fi/events/VjQsm
                     Occurrence: #2010-09-28 05:44:35+00:00 (1 new enrolments)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/VjQsm/occurrences/T2NjdXJyZW5jZU5vZGU6MTA0
+                    Link to occurrence: https://provider.kultus.fi/fi/events/VjQsm/occurrences/T2NjdXJyZW5jZU5vZGU6MTA1
         """,
 ]
 


### PR DESCRIPTION
PT-934. As a provider when I mutate occurrence to API, it should validate the start time against enrolment

Enrolment summary enrolments are ordered by status to get same snapshot every time when running pytest.

NOTE: New design for occurrences could be waited before resolving this pull request, because it's been already talked that occurrence start and end time fields could be changing.  They should not affect on API, but who knows...