### PR TITLE
PT-942 | Make location optional in event mutations

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -185,7 +185,7 @@ def _get_event_keyword_sets(event, keyword_set_id):
 
 class Event(IdObject):
     id = String(required=True)
-    location = Field(Place, required=True)
+    location = Field(Place)
     keywords = NonNull(List(NonNull(Keyword)))
     super_event = Field(IdObject)
     event_status = String()
@@ -463,7 +463,7 @@ class IdObjectInput(InputObjectType):
 
 
 class EventMutationInput(InputObjectType):
-    location = IdObjectInput(required=True)
+    location = IdObjectInput()
     keywords = NonNull(List(NonNull(IdObjectInput)))
     super_event = String()
     event_status = String()

--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -502,15 +502,6 @@ def validate_enrolment(study_group, occurrence, new_enrolment=True):
             raise EnrolmentMaxNeededOccurrenceReached(
                 "Number of enrolled occurrences is greater than the needed occurrences"
             )
-        group_size = (
-            1
-            if occurrence.seat_type == Occurrence.OCCURRENCE_SEAT_TYPE_ENROLMENT_COUNT
-            else study_group.group_size_with_adults()
-        )
-        if occurrence.seats_taken + group_size > occurrence.amount_of_seats:
-            raise EnrolmentNotEnoughCapacityError(
-                "Not enough space for this study group"
-            )
     else:
         if occurrence.seats_taken > occurrence.amount_of_seats:
             raise EnrolmentNotEnoughCapacityError(

--- a/occurrences/tests/snapshots/snap_test_api.py
+++ b/occurrences/tests/snapshots/snap_test_api.py
@@ -419,10 +419,10 @@ snapshots["test_enrol_occurrence 1"] = {
                     "notificationType": "EMAIL",
                     "occurrence": {
                         "amountOfSeats": 50,
-                        "remainingSeats": 30,
+                        "remainingSeats": 50,
                         "seatType": "CHILDREN_COUNT",
                         "seatsApproved": 0,
-                        "seatsTaken": 20,
+                        "seatsTaken": 0,
                         "startTime": "2020-01-06T00:00:00+00:00",
                     },
                     "status": "PENDING",
@@ -432,10 +432,10 @@ snapshots["test_enrol_occurrence 1"] = {
                     "notificationType": "EMAIL",
                     "occurrence": {
                         "amountOfSeats": 2,
-                        "remainingSeats": 1,
+                        "remainingSeats": 2,
                         "seatType": "ENROLMENT_COUNT",
                         "seatsApproved": 0,
-                        "seatsTaken": 1,
+                        "seatsTaken": 0,
                         "startTime": "2020-01-06T00:00:00+00:00",
                     },
                     "status": "PENDING",
@@ -836,7 +836,7 @@ snapshots["test_approve_enrolment_with_custom_message 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: barbarafarrell@yahoo.com
     Click this link to cancel the enrolment:
-    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZToxOV8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZToyMV8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
     Custom message: custom message
 """
@@ -892,7 +892,7 @@ snapshots["test_decline_enrolment_with_custom_message 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: barbarafarrell@yahoo.com
     Click this link to cancel the enrolment:
-    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZToyNF8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZToyNl8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
     Custom message: custom message
 """
@@ -905,9 +905,9 @@ snapshots["test_update_enrolment 1"] = {
                 "notificationType": "SMS",
                 "occurrence": {
                     "amountOfSeats": 35,
-                    "remainingSeats": 1,
+                    "remainingSeats": 35,
                     "seatsApproved": 0,
-                    "seatsTaken": 34,
+                    "seatsTaken": 0,
                     "startTime": "2020-01-06T00:00:00+00:00",
                 },
                 "status": "PENDING",
@@ -970,10 +970,10 @@ snapshots["test_enrol_occurrence_with_captcha 1"] = {
                     "notificationType": "EMAIL",
                     "occurrence": {
                         "amountOfSeats": 50,
-                        "remainingSeats": 30,
+                        "remainingSeats": 50,
                         "seatType": "CHILDREN_COUNT",
                         "seatsApproved": 0,
-                        "seatsTaken": 20,
+                        "seatsTaken": 0,
                         "startTime": "2020-01-06T00:00:00+00:00",
                     },
                     "status": "PENDING",
@@ -1030,10 +1030,10 @@ snapshots["test_enrol_auto_acceptance_occurrence 1"] = {
                     "notificationType": "EMAIL",
                     "occurrence": {
                         "amountOfSeats": 50,
-                        "remainingSeats": 30,
+                        "remainingSeats": 50,
                         "seatType": "CHILDREN_COUNT",
                         "seatsApproved": 0,
-                        "seatsTaken": 20,
+                        "seatsTaken": 0,
                         "startTime": "2020-01-06T00:00:00+00:00",
                     },
                     "status": "PENDING",
@@ -1070,7 +1070,7 @@ snapshots["test_cancel_enrolment_query 1"] = {
     "data": {
         "cancellingEnrolment": {
             "enrolmentTime": "2020-01-04T00:00:00+00:00",
-            "occurrence": {"seatsTaken": 354},
+            "occurrence": {"seatsTaken": 0},
             "status": "PENDING",
             "studyGroup": {
                 "groupSize": 345,

--- a/occurrences/tests/snapshots/snap_test_notifications.py
+++ b/occurrences/tests/snapshots/snap_test_notifications.py
@@ -6,20 +6,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_approve_enrolment_notification_email 1"] = [
-    """no-reply@hel.ninja|['williamsronald@hotmail.com']|Enrolment approved FI|
-    Event FI: Raija Malka & Kaija Saariaho: Blick
-    Extra event info: zVxeo
-    Study group: Dream party door better performance race story. Beautiful if his their. Stuff election stay every.
-    Occurrence: 12.12.2013 06.37
-    Person: williamsronald@hotmail.com
-    Click this link to cancel the enrolment:
-    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo1Ml8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
-
-    Custom message: custom message
-"""
-]
-
 snapshots["test_decline_enrolment_notification_email 1"] = [
     """no-reply@hel.ninja|['williamsronald@hotmail.com']|Enrolment declined FI|
     Event FI: Raija Malka & Kaija Saariaho: Blick
@@ -89,35 +75,6 @@ snapshots["test_local_time_notification[tz2] 1"] = [
     Study group: Increase thank certainly again thought summer. Beyond than trial western.
     Occurrence: 04.01.2020 00.00
     Person: stephanieskinner@gmail.com
-"""
-]
-
-snapshots["test_only_send_approved_notification[False] 1"] = [
-    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Occurrence enrolment FI|
-    Event FI: Raija Malka & Kaija Saariaho: Blick
-    Extra event info: XxEpr
-    Study group: Increase thank certainly again thought summer. Beyond than trial western.
-    Occurrence: 29.06.2001 12.45
-    Person: stephanieskinner@gmail.com
-""",
-    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Enrolment approved FI|
-    Event FI: Raija Malka & Kaija Saariaho: Blick
-    Extra event info: XxEpr
-    Study group: Increase thank certainly again thought summer. Beyond than trial western.
-    Occurrence: 29.06.2001 12.45
-    Person: stephanieskinner@gmail.com
-
-""",
-]
-
-snapshots["test_only_send_approved_notification[True] 1"] = [
-    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Enrolment approved FI|
-    Event FI: Raija Malka & Kaija Saariaho: Blick
-    Extra event info: XxEpr
-    Study group: Increase thank certainly again thought summer. Beyond than trial western.
-    Occurrence: 29.06.2001 12.45
-    Person: stephanieskinner@gmail.com
-
 """
 ]
 
@@ -274,4 +231,47 @@ snapshots["test_decline_enrolment_notification_email_to_multiple_contact_person 
 
     Custom message: custom message
 """,
+]
+
+snapshots["test_only_send_approved_notification[True] 1"] = [
+    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: XxEpr
+    Study group: Increase thank certainly again thought summer. Beyond than trial western.
+    Occurrence: 29.06.2001 12.45
+    Person: stephanieskinner@gmail.com
+
+"""
+]
+
+snapshots["test_only_send_approved_notification[False] 1"] = [
+    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: XxEpr
+    Study group: Increase thank certainly again thought summer. Beyond than trial western.
+    Occurrence: 29.06.2001 12.45
+    Person: stephanieskinner@gmail.com
+""",
+    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: XxEpr
+    Study group: Increase thank certainly again thought summer. Beyond than trial western.
+    Occurrence: 29.06.2001 12.45
+    Person: stephanieskinner@gmail.com
+
+""",
+]
+
+snapshots["test_approve_enrolment_notification_email 1"] = [
+    """no-reply@hel.ninja|['stephanieskinner@gmail.com']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: XxEpr
+    Study group: Increase thank certainly again thought summer. Beyond than trial western.
+    Occurrence: 29.06.2001 12.45
+    Person: stephanieskinner@gmail.com
+    Click this link to cancel the enrolment:
+    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo1NF8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+
+    Custom message: custom message
+"""
 ]

--- a/occurrences/tests/test_api.py
+++ b/occurrences/tests/test_api.py
@@ -1167,6 +1167,7 @@ def test_enrol_full_children_occurrence(api_client, occurrence, mock_get_event_d
     p_event_1 = PalvelutarjotinEventFactory(
         enrolment_start=datetime(2020, 1, 3, 0, 0, 0, tzinfo=timezone.now().tzinfo),
         enrolment_end_days=2,
+        auto_acceptance=True,
     )
     occurrence = OccurrenceFactory(
         start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
@@ -1209,13 +1210,14 @@ def test_enrol_full_enrolment_occurrence(api_client, occurrence, mock_get_event_
     p_event_1 = PalvelutarjotinEventFactory(
         enrolment_start=datetime(2020, 1, 3, 0, 0, 0, tzinfo=timezone.now().tzinfo),
         enrolment_end_days=2,
+        auto_acceptance=True,
     )
     occurrence = OccurrenceFactory(
         start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
         p_event=p_event_1,
         min_group_size=10,
         max_group_size=101,
-        amount_of_seats=2,
+        amount_of_seats=1,
         seat_type=Occurrence.OCCURRENCE_SEAT_TYPE_ENROLMENT_COUNT,
     )
 

--- a/occurrences/tests/test_models.py
+++ b/occurrences/tests/test_models.py
@@ -129,7 +129,7 @@ def test_study_group_size_with_adults(group_size, amount_of_adult, result):
 
 @pytest.mark.django_db
 def test_occurrence_seat_taken():
-    enrolment = EnrolmentFactory()
+    enrolment = EnrolmentFactory(status=Enrolment.STATUS_APPROVED)
     occurrence = enrolment.occurrence
     study_group = enrolment.study_group
     assert occurrence.seats_taken > 0

--- a/occurrences/tests/test_notifications.py
+++ b/occurrences/tests/test_notifications.py
@@ -101,9 +101,9 @@ def test_approve_enrolment_notification_email(
     notification_template_enrolment_approved_en,
     notification_template_enrolment_approved_fi,
     snapshot,
-    occurrence,
-    study_group,
 ):
+    study_group = StudyGroupFactory(group_size=5)
+    occurrence = OccurrenceFactory(amount_of_seats=10)
     enrolment = EnrolmentFactory(
         study_group=study_group, occurrence=occurrence, person=study_group.person
     )
@@ -247,9 +247,11 @@ def test_only_send_approved_notification(
     notification_template_enrolment_approved_en,
     notification_template_occurrence_enrolment_fi,
     notification_template_enrolment_approved_fi,
-    study_group,
 ):
-    occurrence = OccurrenceFactory(p_event__auto_acceptance=auto_acceptance)
+    study_group = StudyGroupFactory(group_size=5)
+    occurrence = OccurrenceFactory(
+        p_event__auto_acceptance=auto_acceptance, amount_of_seats=10
+    )
     enrol = EnrolmentFactory(
         study_group=study_group, occurrence=occurrence, person=study_group.person
     )


### PR DESCRIPTION
Since location selector is moved to Step 2 in the new event creation wizard, it should be possible for FE to create draft event without location. GraphQL API should make this field optional in the mutation