### PR TITLE
Exportable event enrolments stats on admin site

### DIFF
--- a/occurrences/templates/admin/palvelutarjotinevent_changelist.html
+++ b/occurrences/templates/admin/palvelutarjotinevent_changelist.html
@@ -1,0 +1,27 @@
+{% extends 'admin/change_list.html' %}
+{% load i18n %}
+{% block object-tools-items %}
+{% now "Y" as current_year %}
+<li>
+    <a href="{% url 'report_event_enrolments_csv' %}?start={{current_year|add:'-1'}}-01-01&end={{current_year|add:'-1'}}-07-01">
+        {% blocktrans with previous_year=current_year|add:'-1' %}Export enrolments spring {{previous_year}}{% endblocktrans %}
+    </a>
+</li>
+<li>
+    <a
+        href="{% url 'report_event_enrolments_csv' %}?start={{current_year|add:'-1'}}-07-01&end={{current_year|add:'-1'}}-12-31">
+        {% blocktrans with previous_year=current_year|add:'-1' %}Export enrolments autumn {{previous_year}}{% endblocktrans %}
+    </a>
+</li>
+<li>
+    <a href="{% url 'report_event_enrolments_csv' %}?start={{current_year}}-01-01&end={{current_year}}-07-01">
+        {% blocktrans %}Export enrolments spring {{current_year}}{% endblocktrans %}
+    </a>
+</li>
+<li style="margin-right: 100px">
+    <a href="{% url 'report_event_enrolments_csv' %}?start={{current_year}}-07-01">
+        {% blocktrans %}Export enrolments autumn {{current_year}}{% endblocktrans %}
+    </a>
+</li>
+{{ block.super }}
+{% endblock %}

--- a/reports/templates/reports/admin/event_enrolments.html
+++ b/reports/templates/reports/admin/event_enrolments.html
@@ -1,0 +1,57 @@
+{% extends "admin/base.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% trans "Events' enrolments report"%}
+</div>
+{% endblock %}
+
+{% block content %}
+<table>
+    <caption>{% trans "Events' approved enrolments" %}</caption>
+    <thead>
+        <tr>
+            <th>{% trans "LinkedEvents id" %}</th>
+            <th>{% trans "Occurrence starting time" %}</th>
+            <th>{% trans "Enrolment time" %}</th>
+            <th>{% trans "Group name" %}</th>
+            <th>{% trans "Study levels" %}</th>
+            <th>{% trans "Amount of children" %}</th>
+            <th>{% trans "Amount of adults" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for enrolment in enrolments %}
+            <tr>
+                <td><a href="{{linked_events_root}}event/{{enrolment.occurrence.p_event.linked_event_id}}" target="blank">{{enrolment.occurrence.p_event.linked_event_id}}</a></td>
+                <td>{{enrolment.occurrence.start_time|date:"d.m.Y H:i"}}</td>
+                <td>{{enrolment.enrolment_time|date:"d.m.Y H:i"}}</td>
+                <td>{{enrolment.study_group.name}}</td>
+                <td>
+                    {% for study_level in enrolment.study_group.study_levels.all %}
+                        {% if not forloop.first %}, {% endif %}
+                        {{study_level.label}}
+                    {% endfor %}
+                </td>
+                <td>{{enrolment.study_group.group_size}}</td>
+                <td>{{enrolment.study_group.amount_of_adult}}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            <td><b>{% trans "Total" %}:</b> {{enrolments|length}}</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>{{total_children}}</td>
+            <td>{{total_adults}}</td>
+        </tr>
+    </tfoot>
+</table>
+{% endblock %}

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
-from reports.views import OrganisationPersonsAdminView, OrganisationPersonsCsvView
+from reports.views import (
+    OrganisationPersonsAdminView,
+    OrganisationPersonsCsvView,
+    PalvelutarjotinEventEnrolmentsAdminView,
+    PalvelutarjotinEventEnrolmentsCsvView,
+)
 
+# Admin views
 urlpatterns = [
     path(
         "organisation/persons/",
@@ -8,8 +14,22 @@ urlpatterns = [
         name="report_organisation_persons",
     ),
     path(
+        "palvelutarjotinevent/enrolments/",
+        PalvelutarjotinEventEnrolmentsAdminView.as_view(),
+        name="report_event_enrolments",
+    ),
+]
+
+# CSV views
+urlpatterns += [
+    path(
         "organisation/persons/csv/",
         OrganisationPersonsCsvView.as_view(),
         name="report_organisation_persons_csv",
+    ),
+    path(
+        "palvelutarjotinevent/enrolments/csv/",
+        PalvelutarjotinEventEnrolmentsCsvView.as_view(),
+        name="report_event_enrolments_csv",
     ),
 ]

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,13 +1,25 @@
 import csv
+import datetime
+import logging
 
+from django.conf import settings
+from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models.query import Prefetch
 from django.http.response import HttpResponse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.generic import ListView
 from django.views.generic.base import View
+from occurrences.models import Enrolment, PalvelutarjotinEvent
 from organisations.models import Organisation, Person
+
+logger = logging.getLogger(__name__)
+
+
+def naive_datetime_to_tz_aware(datetime: str) -> str:
+    return datetime + "T00:00:00.000Z" if datetime else None
 
 
 class ExportReportViewMixin:
@@ -49,6 +61,81 @@ class OrganisationPersonsMixin(ExportReportViewMixin):
         )
 
 
+class PalvelutarjotinEventEnrolmentsMixin(ExportReportViewMixin):
+
+    max_results = 2000
+
+    def message_max_result(self, request):
+        # Inform the user if not all the data was included
+        if len(self.get_queryset()) == self.max_results:
+            logger.warning(
+                "Queryset items maximum count exceeded "
+                + "when fetching data for events enrolments report."
+            )
+            messages.add_message(
+                request,
+                messages.WARNING,
+                _(
+                    "Maximum count exceeded (%(max_results)s) "
+                    + "when exporting events enrolments: "
+                    + "Some of the data (older) might be missing."
+                )
+                % {"max_results": self.max_results},
+            )
+
+    def get_queryset(self):
+        """
+        Fetch enrolments instead of palvelutarjotineEvent instances.
+        This means that events and occurrences without any enrolments
+        wont be included!
+        """
+        queryset = Enrolment.objects.filter(status=Enrolment.STATUS_APPROVED)
+
+        # Get URL parameter as a string, if exists
+        event_ids = self.request.GET.get("ids", None)
+        # Get organisations for ids if they exist
+        if event_ids is not None:
+            # Convert parameter string to list of integers
+            event_ids = [int(x) for x in event_ids.split(",")]
+            # Get objects for all parameter ids
+            queryset = queryset.filter(occurrence__p_event__id__in=event_ids)
+
+        start_date = naive_datetime_to_tz_aware(self.request.GET.get("start", None))
+        end_date = naive_datetime_to_tz_aware(self.request.GET.get("end", None))
+
+        if start_date and end_date:
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__range=[start_date, end_date]
+            )
+        elif start_date:
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__gte=start_date
+            )
+        elif end_date:
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__lte=end_date
+            )
+
+        if not event_ids and not start_date and not end_date:
+            # Get this years enrolments
+            today = datetime.datetime.now(tz=timezone.utc)
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__year=today.year
+            )
+
+        # Order by occurrence start time
+        # and select all related content that is needed in report.
+        # In case a whole db is trying to be fetched, limit the amount of fetched items
+        return queryset.order_by(
+            "-occurrence__p_event__enrolment_start"
+        ).select_related("occurrence__p_event", "study_group")[: self.max_results]
+
+
+"""
+Admin views...
+"""
+
+
 @method_decorator(staff_member_required, name="dispatch")
 class OrganisationPersonsAdminView(OrganisationPersonsMixin, ListView):
     """
@@ -63,6 +150,47 @@ class OrganisationPersonsAdminView(OrganisationPersonsMixin, ListView):
         context = super(OrganisationPersonsAdminView, self).get_context_data(**kwargs)
         context["opts"] = self.model._meta
         return context
+
+
+@method_decorator(staff_member_required, name="dispatch")
+class PalvelutarjotinEventEnrolmentsAdminView(
+    PalvelutarjotinEventEnrolmentsMixin, ListView
+):
+    """
+    The admin view which renders a table of events occurrences and enrolments.
+    """
+
+    model = PalvelutarjotinEvent
+    template_name = "reports/admin/event_enrolments.html"
+    context_object_name = "enrolments"
+
+    def get(self, request, *args, **kwargs):
+
+        # Inform the user if not all the data was included
+        self.message_max_result(request)
+
+        return super(PalvelutarjotinEventEnrolmentsAdminView, self).get(
+            request, *args, **kwargs
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super(PalvelutarjotinEventEnrolmentsAdminView, self).get_context_data(
+            **kwargs
+        )
+        context["linked_events_root"] = settings.LINKED_EVENTS_API_CONFIG["ROOT"]
+        context["total_children"] = sum(
+            enrolment.study_group.group_size for enrolment in self.get_queryset()
+        )
+        context["total_adults"] = sum(
+            enrolment.study_group.amount_of_adult for enrolment in self.get_queryset()
+        )
+        context["opts"] = self.model._meta
+        return context
+
+
+"""
+CSV Views...
+"""
 
 
 @method_decorator(staff_member_required, name="dispatch")
@@ -99,10 +227,10 @@ class OrganisationPersonsCsvView(OrganisationPersonsMixin, ExportReportCsvView):
 
     def get(self, request, *args, **kwargs):
 
-        meta = self.model._meta
-
         response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = "attachment; filename={}.csv".format(meta)
+        response["Content-Disposition"] = "attachment; filename={}.csv".format(
+            "kultus_organisations_persons"
+        )
         writer = csv.writer(response)
 
         writer.writerow([_("Organisation"), _("Name"), _("Email"), _("Phone")])
@@ -116,4 +244,60 @@ class OrganisationPersonsCsvView(OrganisationPersonsMixin, ExportReportCsvView):
                         person.phone_number,
                     ]
                 )
+        return response
+
+
+@method_decorator(staff_member_required, name="dispatch")
+class PalvelutarjotinEventEnrolmentsCsvView(
+    PalvelutarjotinEventEnrolmentsMixin, ExportReportCsvView
+):
+    """
+    A csv of organisations persons.
+    """
+
+    model = PalvelutarjotinEvent
+
+    def get(self, request, *args, **kwargs):
+        # Inform the user if not all the data was included
+        self.message_max_result(request)
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename={}.csv".format(
+            "kultus_events_approved_enrolments"
+        )
+        writer = csv.writer(response)
+
+        writer.writerow(
+            [
+                _("LinkedEvents id"),
+                _("LinkedEvents uri"),
+                _("Occurrence starting (date)"),
+                _("Enrolment date"),
+                _("Group name"),
+                _("Study levels"),
+                _("Amount of children"),
+                _("Amount of adults"),
+            ]
+        )
+        for enrolment in self.get_queryset():
+            writer.writerow(
+                [
+                    enrolment.occurrence.p_event.linked_event_id,
+                    "{linked_events_root}event/{linked_event_id}".format(
+                        linked_events_root=settings.LINKED_EVENTS_API_CONFIG["ROOT"],
+                        linked_event_id=enrolment.occurrence.p_event.linked_event_id,
+                    ),
+                    enrolment.occurrence.start_time,
+                    enrolment.enrolment_time,
+                    enrolment.study_group.name,
+                    ", ".join(
+                        [
+                            study_level.label
+                            for study_level in enrolment.study_group.study_levels.all()
+                        ]
+                    ),
+                    enrolment.study_group.group_size,
+                    enrolment.study_group.amount_of_adult,
+                ]
+            )
         return response


### PR DESCRIPTION
PT-958. With new admin site actions, events enrolments can be viewed in admin site or exported to a CSV file.

NOTE: There are some dependencies. This is based on other PRs. Pull requests #148 and #149 should be merged first!

Admin report view in URL
/reports/palvelutarjotinevent/enrolments/

![image](https://user-images.githubusercontent.com/389204/115728519-3cc21280-a38d-11eb-8626-9e4204e04226.png)

CSV can be imported from 
/reports/palvelutarjotinevent/enrolments/csv/
![image](https://user-images.githubusercontent.com/389204/115728621-51060f80-a38d-11eb-8c71-51aedf1aa938.png)

Parameters can be:
- ?ids=1,2,3,4
- ?start=2021-02-02
- ?start=2021-02-02&end=2021-05-03
- ?end=2021-05-03