### PR TITLE
Fixed user saving on admin site when there is no link to a person instance.

### DIFF
--- a/organisations/admin.py
+++ b/organisations/admin.py
@@ -56,7 +56,7 @@ class UserAdminForm(UserChangeForm):
         if commit:
             user.save()
 
-        if user.pk:
+        if user.pk and hasattr(user, "person"):
             user.person.organisations.set(self.cleaned_data["organisations"])
             self.save_m2m()
 

--- a/organisations/models.py
+++ b/organisations/models.py
@@ -19,6 +19,15 @@ class PersonQuerySet(models.QuerySet):
 
 
 class User(AbstractUser):
+
+    # When creating an user, the name and the email can be left to blank.
+    # In those cases, return username.
+    def __str__(self):
+        display_name = super(User, self).__str__()
+        if not display_name:
+            return self.username
+        return display_name
+
     class Meta:
         verbose_name = _("user")
         verbose_name_plural = _("users")

--- a/organisations/tests/test_models.py
+++ b/organisations/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
-from organisations.factories import OrganisationFactory, PersonFactory
+from organisations.factories import OrganisationFactory, PersonFactory, UserFactory
 from organisations.models import Organisation, Person
 
 User = get_user_model()
@@ -27,3 +27,37 @@ def test_membership_creation():
     assert person.organisations.count() == 3
     assert Organisation.objects.count() == 3
     assert Person.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_user_str():
+    user_with_name_and_email = UserFactory.create(
+        first_name="first_name",
+        last_name="last_name",
+        username="user_with_name_and_email",
+        email="user_with_name_and_email@email.com",
+    )
+    assert user_with_name_and_email.__str__() == "%s %s (%s)" % (
+        user_with_name_and_email.last_name,
+        user_with_name_and_email.first_name,
+        user_with_name_and_email.email,
+    )
+
+    user_without_full_name_but_email = UserFactory.create(
+        first_name="",
+        last_name="last_name",
+        username="user_without_full_name_but_email",
+        email="user_without_full_name_but_email@email.com",
+    )
+    assert (
+        user_without_full_name_but_email.__str__()
+        == user_without_full_name_but_email.email
+    )
+
+    user_without_name_and_email = UserFactory.create(
+        first_name="",
+        last_name="last_name",
+        username="user_without_name_and_email",
+        email="",
+    )
+    assert user_without_name_and_email.__str__() == user_without_name_and_email.username


### PR DESCRIPTION
PT-994. Use username in user listing when name and email are not available