### PR TITLE
Forced event type to general.

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -539,6 +539,10 @@ def validate_p_event_data(p_event_data):
         )
 
 
+def _force_event_type_id(event_body: object):
+    event_body["type_id"] = "general"
+
+
 class AddEventMutation(Mutation):
     class Arguments:
         event = AddEventMutationInput()
@@ -571,7 +575,9 @@ class AddEventMutation(Mutation):
                 "publication_status"
             ] = PalvelutarjotinEvent.PUBLICATION_STATUS_DRAFT
 
-        body = format_request(kwargs["event"])
+        event_body = kwargs["event"]
+        _force_event_type_id(event_body)
+        body = format_request(event_body)
         # TODO: proper validation if necessary
         result = api_client.create("event", body)
         event_obj = json2obj(format_response(result))
@@ -642,7 +648,9 @@ class UpdateEventMutation(Mutation):
                 "publication_status"
             ] = PalvelutarjotinEvent.PUBLICATION_STATUS_DRAFT
 
-        body = format_request(kwargs["event"])
+        event_body = kwargs["event"]
+        _force_event_type_id(event_body)
+        body = format_request(event_body)
         # TODO: proper validation if necessary
         result = api_client.update("event", event_id, body)
         if result.status_code == 200 and p_event_data:


### PR DESCRIPTION
PT-1044 Forcing the event type id to "general". Pull request #173 was to add a type id field to  the event schema, but there were problems with default_value used with required -attribute. More about that: https://github.com/graphql-python/graphene/commit/c08379ed85b2759de32777eb5dd3dca143a6d69f.