### PR TITLE
Revert "Forced event type to general."

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -539,10 +539,6 @@ def validate_p_event_data(p_event_data):
         )
 
 
-def _force_event_type_id(event_body: object):
-    event_body["type_id"] = "general"
-
-
 class AddEventMutation(Mutation):
     class Arguments:
         event = AddEventMutationInput()
@@ -575,9 +571,7 @@ class AddEventMutation(Mutation):
                 "publication_status"
             ] = PalvelutarjotinEvent.PUBLICATION_STATUS_DRAFT
 
-        event_body = kwargs["event"]
-        _force_event_type_id(event_body)
-        body = format_request(event_body)
+        body = format_request(kwargs["event"])
         # TODO: proper validation if necessary
         result = api_client.create("event", body)
         event_obj = json2obj(format_response(result))
@@ -648,9 +642,7 @@ class UpdateEventMutation(Mutation):
                 "publication_status"
             ] = PalvelutarjotinEvent.PUBLICATION_STATUS_DRAFT
 
-        event_body = kwargs["event"]
-        _force_event_type_id(event_body)
-        body = format_request(event_body)
+        body = format_request(kwargs["event"])
         # TODO: proper validation if necessary
         result = api_client.update("event", event_id, body)
         if result.status_code == 200 and p_event_data:


### PR DESCRIPTION
Reverts City-of-Helsinki/palvelutarjotin#174

There were no use for this.

LinkedEvents team told that the test server and the production server are currently having a version that contains type_id in the Event model. They also told that after that version, it is needed to contain type_id in an event post and it should be in format {"type_id": "general"}. The type_id has been added in branch feature/event_type in commit 970d8ef607d600eb5fee84413ffacd25fc3fbb0b. In that version, **type_id is actually an enum, not a string!**. In that sense, we should post {"type_id": 1} instead. However, general type is also set to nullable in api (https://github.com/City-of-Helsinki/linkedevents/pull/459/files#diff-f645847ab170537ed98cb30203db3f05c21afd0c3b69fc2fd32a667f5f9b6e03R1364) and it's default in the model (https://github.com/City-of-Helsinki/linkedevents/pull/459/files#diff-e22db1fd6b46c1799d0bb96df4d30720dba88c4ab310face6db5d9f9379a473cR654). 

So, I also tested this branch on my local machine. I ran LinkedEvents in docker (which was super hard to setup since it was missing couple of migrations). Type id really is not needed! Here is a successfull curl

```
curl --request POST \
  --url http://localhost:8000/v1/event/ \
  --header 'Content-Type: application/json' \
  --header 'apikey: 234567892345678' \
  --data '{
	"keywords": [

	],
	"offers": [
		{
			"is_free": true,
			"description": {
				"fi": "",
				"sv": "",
				"en": ""
			},
			"price": {
				"fi": "",
				"sv": "",
				"en": ""
			}
		}
	],
	"images": [],
	"in_language": [],
	"audience": [

	],
	"start_time": "2021-05-21T11:07:13.895Z",
	"name": {
		"fi": "5X2 JA 2X5 -TAIDEKURSSIT ANNANTALOLLA - SYKSY 2021",
		"sv": "",
		"en": ""
	},
	"short_description": {
		"fi": "5x2 ja 2x5 ovat maksuttomia taidekursseja helsinkil\\u00e4isille alakoululuokille. Jokainen luokka p\\u00e4\\u00e4see 5x2 tai 2x5 taidekursseille kerran alakouluaikanaan.",
		"sv": "",
		"en": ""
	},
	"info_url": {
		"fi": "http://www.annantalo.fi/fi/5x2taideopetus",
		"sv": "",
		"en": ""
	},
	"description": {
		"fi": "MIK\\u00c4 5x2 JA 2x5 -TAIDEOPETUS? \\n\\n5x2 -kursseille mahtuvat kaikenkokoiset ja muotoiset ala-koululuokat. Osallistuva luokka jakautuu pienryhmiin, jotka opiskelevat eri taideaineita. Voidakseen osallistua n\\u00e4ille kursseille, on luokan pystytt\\u00e4v\\u00e4 sitoutumaan kaikkiin viiteen opetuskertaan. Jokainen luokka p\\u00e4\\u00e4see kursseille kerran.\\n\\nAnnantalolla osa 5x2-opetuksesta toteutetaan 2x5-muotoisena. N\\u00e4ille kursseille luokat tulevat vain kaksi kertaa, molemmilla kerroilla kurssip\\u00e4iv\\u00e4n pituus on 5 oppituntia (klo 9.15 - 13.30)",
		"sv": "",
		"en": ""
	},
	"draft": true,
	"publisher": "ahjo:00001",
	"publication_status": "draft"
}'
```

![image](https://user-images.githubusercontent.com/389204/119201948-8723d580-ba98-11eb-81f4-8a6786eb7486.png)
