### PR TITLE
Fixes to CSV file when reading it with Microsoft Excel

### DIFF
--- a/reports/views.py
+++ b/reports/views.py
@@ -220,14 +220,44 @@ class ExportReportCsvView(ExportReportViewMixin, APIView):
     authentication_classes = [ApiTokenAuthentication, SessionAuthentication]
     permission_classes = [IsAdminUser]
     csv_dialect = csv.excel
+    csv_delimiter = ";"
 
     def _create_csv_response_writer(self, filename):
-        response = HttpResponse(content_type="text/csv; text/csv; charset=utf-8")
+        response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = "attachment; filename={}.csv".format(filename)
-        response.write(
-            f"sep={self.csv_dialect.delimiter}{self.csv_dialect.lineterminator}"
+
+        """
+        Adding BOM is not advicable, and UTF-8 shouldn't even have that,
+        but Microsoft product seems to sometimes need it.
+        """
+        response.write("\ufeff")
+
+        """
+        CSV is a delimited text file that uses a comma to separate values
+        (many implementations of CSV import/export tools allow other
+        separators to be used; for example, the use of a "Sep=^" row
+        as the first row in the csv file will cause Excel to open
+        the file expecting caret "^" to be the separator instead of comma ",").
+        ~ https://en.wikipedia.org/wiki/Comma-separated_values.
+        NOTE: At least when using a comma as a delimiter,
+        the separator is needed to be defined for Microsoft Excel.
+        NOTE: When tested with Microsoft Excel for Mac, strangely,
+        it seems to help Excel to choose the delimiter, but seems to break encoding
+        and the scandinavian letters are not shown properly.
+        """
+        # response.write(f"sep={self.csv_delimiter}{self.csv_dialect.lineterminator}")
+
+        """
+        The CSV library uses Excel as the default dialect,
+        but Excel still seems not to work properly with it,
+        since there were issues with the separator and the encoding.
+        Using the semicolon (";") as a delimiter
+        seems to fix UTF-8 issues with Microsoft Excel.
+        """
+        writer = csv.writer(
+            response, dialect=self.csv_dialect, delimiter=self.csv_delimiter
         )
-        writer = csv.writer(response, dialect=self.csv_dialect)
+
         return (writer, response)
 
     def get(self, request, *args, **kwargs):
@@ -235,7 +265,6 @@ class ExportReportCsvView(ExportReportViewMixin, APIView):
         meta = self.model._meta
         field_names = [field.name for field in meta.fields]
         writer, response = self._create_csv_response_writer(meta)
-        writer = self.create_csv_writer(response)
         writer.writerow(field_names)
         for obj in queryset:
             writer.writerow([getattr(obj, field) for field in field_names])


### PR DESCRIPTION
PT-1052. Set BOM and semicolon as a delimiter to fix the encoding issues.

Screenshot from Microsoft Excel for Mac:
![image](https://user-images.githubusercontent.com/389204/122687572-cd975c00-d21f-11eb-8df4-1f1b66b8e906.png)


FYI: 
- https://docs.python.org/3/library/csv.html
- https://stackoverflow.com/questions/5202648/adding-bom-unicode-signature-while-saving-file-in-python
- https://theonemanitdepartment.wordpress.com/2014/12/15/the-absolute-minimum-everyone-working-with-data-absolutely-positively-must-know-about-file-types-encoding-delimiters-and-data-types-no-excuses/
- https://en.wikipedia.org/wiki/Comma-separated_values