### PR TITLE
Persons language is now editable in admin.

### DIFF
--- a/organisations/tests/snapshots/snap_test_notifications.py
+++ b/organisations/tests/snapshots/snap_test_notifications.py
@@ -36,7 +36,7 @@ klikkaa <a href="https://test-domain/admin/organisations/user/123/change/" targe
 
     <p>Erityisviesti: custom message</p>
 """,
-    """no-reply@hel.ninja|['brownheather@villarreal.com']|My profile creation FI|
+    """no-reply@hel.ninja|['lmathis@ortiz.com']|My profile creation FI|
 <p>Hyvä Kultus ylläpitäjä!</p>
 <p>Uusi palveluntarjoajan tunnus on luotu!</p>
 <address>
@@ -65,9 +65,38 @@ klikkaa <a href="https://test-domain/admin/organisations/user/123/change/" targe
 
     <p>Erityisviesti: custom message</p>
 """,
+    """no-reply@hel.ninja|['mendezjonathan@espinoza.biz']|My profile creation EN|
+<p>Dear Kultus Admin!</p>
+<p>A new Kultus provider user profile is created!</p>
+<address>
+    William Brewer<br />
+    <a href="mailto:stephanieskinner@gmail.com">stephanieskinner@gmail.com</a>
+    Username: ariley
+</address>
+<p>The provider who created the user profile needs an admin (you)
+to accept the user profile:</p>
+<ol>
+    <li>Create the missing organisations to LinkedEvents</li>
+    <li>Create the missing organisations to Kultus</li>
+    <li>Link the user to organisations</li>
+    <li>Set the staff -flag so the user would receive the permissions
+    to create and edit their events.</li>
+</ol>
+<p>The user would like to represent these organisations:</p>
+<ul>
+    <li>Bell, Price and Dixon</li>
+    <li>Perry Ltd</li>
+</ul>
+<p>To edit the newly created user profile,
+click <a href="https://test-domain/admin/organisations/user/123/change/" target="_blank">here</a>!</p>
+<p>To see a full list of users, click
+<a href="https://test-domain/admin/organisations/user/" target="_blank">here</a>.</p>
+
+    <p>Custom message: custom message</p>
+""",
 ]
 
-snapshots["test_myprofile_accepted_email 1"] = [
+snapshots["test_myprofile_accepted_email[fi] 1"] = [
     """no-reply@hel.ninja|['patrick24@yahoo.com']|My profile accepted FI|
 <p>Hei Amanda George!</p>
 <p>Sinun käyttäjäsi on nyt valmis käytettäväksi Kultuksessa
@@ -78,5 +107,19 @@ seuraavilla organisaatioille:</p>
 </ul>
 
     <p>Erityisviesti: custom message</p>
+    """
+]
+
+snapshots["test_myprofile_accepted_email[en] 1"] = [
+    """no-reply@hel.ninja|['patrick24@yahoo.com']|My profile accepted EN|
+<p>Hi Amanda George!</p>
+<p>Your account is now ready to be used in Kultus
+with the following organisations linked to your account:</p>
+<ul>
+    <li>Black Ltd</li>
+    <li>Burns, Gomez and Roach</li>
+</ul>
+
+    <p>Custom message: custom message</p>
     """
 ]

--- a/organisations/tests/test_notifications.py
+++ b/organisations/tests/test_notifications.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.core import mail
 from organisations.factories import (
     OrganisationFactory,
@@ -21,20 +22,26 @@ def test_myprofile_creation_email(
     user = UserFactory(id=123)
     person = PersonFactory(user=user)
     OrganisationProposalFactory.create_batch(2, applicant=person)
-    UserFactory.create_batch(2, is_admin=True)
+    PersonFactory(user=UserFactory(is_admin=True))
+    PersonFactory(user=UserFactory(is_admin=True), language="fi")
+    PersonFactory(user=UserFactory(is_admin=True), language="en")
+    assert get_user_model().objects.filter(is_admin=True).count() == 3
+
     person.notify_myprofile_creation(custom_message="custom message")
-    assert len(mail.outbox) == 2
+    assert len(mail.outbox) == 3
     assert_mails_match_snapshot(snapshot)
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("language", ["fi", "en"])
 def test_myprofile_accepted_email(
+    language,
     snapshot,
     notification_template_myprofile_accepted_fi,
     notification_template_myprofile_accepted_en,
 ):
     organisations = OrganisationFactory.create_batch(2)
-    person = PersonFactory(organisations=organisations)
+    person = PersonFactory(organisations=organisations, language=language)
     person.notify_myprofile_accepted(custom_message="custom message")
     assert len(mail.outbox) == 1
     assert_mails_match_snapshot(snapshot)

--- a/reports/tests/test_views.py
+++ b/reports/tests/test_views.py
@@ -305,6 +305,7 @@ class OrganisationPersonsCsvViewTest(TestCase):
 
 
 class PalvelutarjotinEventEnrolmentsTest(TestCase):
+    @pytest.mark.django_db
     def test_export_enrolment_csv_data(self):
         today = datetime.datetime.now(tz=timezone.utc)
         p_events = PalvelutarjotinEventFactory.create_batch(3, enrolment_start=today)


### PR DESCRIPTION
PT-1090. Added a language field to person admin form.
Show only the users without  link to any person in person admin.

PT-1090
Added UserPersonInLine form to User admin change form.

PT-1090 Added person inline form in user change form, so it would be easier to find the person instance linked to the user.
Using admins and persons own language in my profile notifications.

PT-1090.
Changed the email is sent info message for admins.

PT-1096.

![image](https://user-images.githubusercontent.com/389204/125293778-69eae500-e32c-11eb-96eb-8f56c0969f35.png)
