### PR TITLE
Fixing issues when the link fails between palvelutarjotin event and linked event's event

### DIFF
--- a/graphene_linked_events/tests/snapshots/snap_test_api.py
+++ b/graphene_linked_events/tests/snapshots/snap_test_api.py
@@ -93,81 +93,10 @@ snapshots["test_get_events 1"] = {
                     "subEvents": [],
                     "superEvent": None,
                     "superEventType": None,
-                },
-                {
-                    "audience": [],
-                    "audienceMaxAge": None,
-                    "audienceMinAge": None,
-                    "createdTime": "2019-12-13T12:49:40.545273Z",
-                    "customData": None,
-                    "dataSource": "helsinki",
-                    "datePublished": None,
-                    "description": {
-                        "en": "<p>Visual artist Raija Malka and composer Kaija Saariaho will take over Amos Rex’s exhibition space in a new and experiential way next summer. The work is painterly, spatial and musical all at once, offering visitors an opportunity to shape the space with their own creativity.</p><p>The exhibition title, Blick (Gaze), is a reference to visual artist Wassily Kandinsky’s poem from 1912 that is included in the soundscape by Kaija Saariaho. The gazes of the two artists are brought together in a three-dimensional space.</p><p>The exhibition is a multisensory experience that invites people to stay. In a world made up of the colours and sounds of Malka and Saariaho, visitors can build their own arrangements.</p><p>Amos Rex<br>10.6.-30.8. </p><p>Mon, Fri 11.00-18.00<br>Wed, Thu 11.00-20.00<br>Sat, Sun 11.00-17.00</p><p>Admission fee 5-15€, under 18 yrs free entry</p>",
-                        "fi": "<p>Kuvataiteilija Raija Malka ja säveltäjä Kaija Saariaho täyttävät ensi kesänä Amos Rexin näyttelytilan uudella kokemuksellisella tavalla. Teos on yhtä aikaa maalauksellinen, tilallinen ja musiikillinen. </p><p>Näyttelyn nimi Blick (Katse) viittaa kuvataiteilija Wassily Kandinskyn 1912 julkaistuun runoon, joka sisältyy Kaija Saariahon näyttelyssä kuultavaan äänimaisemaan. Kahden taiteilijan katseet yhdistyvät näyttelyn kolmiulotteisessa tilassa.</p><p>Näyttely on moniaistinen kokonaisuus, joka houkuttelee viipymään. Kävijä voi rakentaa omia asetelmiaan Malkan ja Saariahon väri- ja äänimaailmaan.</p><p>Amos Rex<br>10.6.-30.8. </p><p>ma, pe klo 11-18<br>ke, to klo 11-20<br>la, su klo 11-17</p><p>Sisäänpääsy 5-15€, alle 18-vuotiaille vapaa pääsy</p>",
-                        "sv": "<p>Bildkonstnären Raija Malka och kompositören Kaija Saariaho fyller Amos Rex utställningsutrymme på ett nytt och experimentellt sätt nästa sommaren. Deras verk är på en och samma gång måleriskt, rumsligt och musikaliskt. </p><p>Utställningstiteln, Blick, syftar på bildkonstnären Wassily Kandinskys dikt från 1912. Texten ingår i Kaija Saariahos ljuder i utställningen. De två konstnärernas blickar möts i det tredimensionella utställningsutrymmet.</p><p>Utställningen utgör en sinnlig helhet som lockar besökare att dröja kvar. De kan bidra till Malkas och Saariahos färg- och ljudvärld med sina egna byggstenar.</p><p>Amos Rex<br>10.6.-30.8. </p><p>må, fre kl 11-18<br>ons, to kl 11-20<br>lö, sö kl 11-17</p><p>Inträde 5-15€, under 18 år fritt inträde</p>",
-                    },
-                    "endTime": None,
-                    "eventStatus": "EventPostponed",
-                    "extensionCourse": None,
-                    "externalLinks": [],
-                    "id": "helsinki:afxp6tv4xa",
-                    "images": [
-                        {
-                            "internalId": "https://api.hel.fi/linkedevents/v1/image/61106/"
-                        }
-                    ],
-                    "inLanguage": [],
-                    "infoUrl": {
-                        "en": "http://www.amosrex.fi",
-                        "fi": "http://www.amosrex.fi",
-                        "sv": "http://www.amosrex.fi",
-                    },
-                    "internalContext": "http://schema.org",
-                    "internalId": "https://api.hel.fi/linkedevents/v1/event/helsinki:afxp6tv4xa/",
-                    "internalType": "Event/LinkedEvent",
-                    "keywords": [
-                        {
-                            "internalId": "https://api.hel.fi/linkedevents/v1/keyword/helfi:12/"
-                        },
-                        {
-                            "internalId": "https://api.hel.fi/linkedevents/v1/keyword/yso:p5121/"
-                        },
-                        {
-                            "internalId": "https://api.hel.fi/linkedevents/v1/keyword/yso:p6889/"
-                        },
-                        {
-                            "internalId": "https://api.hel.fi/linkedevents/v1/keyword/yso:p1808/"
-                        },
-                    ],
-                    "lastModifiedTime": "2020-05-05T09:24:58.569334Z",
-                    "localizationExtraInfo": None,
-                    "location": {
-                        "internalId": "https://api.hel.fi/linkedevents/v1/place/tprek:55959/"
-                    },
-                    "name": {
-                        "en": "Raija Malka & Kaija Saariaho: Blick",
-                        "fi": "Raija Malka & Kaija Saariaho: Blick",
-                        "sv": "Raija Malka & Kaija Saariaho: Blick",
-                    },
-                    "offers": [{"isFree": False}],
-                    "provider": {"en": "Amos Rex", "fi": "Amos Rex", "sv": "Amos Rex"},
-                    "providerContactInfo": None,
-                    "publicationStatus": None,
-                    "publisher": "ytj:0586977-6",
-                    "shortDescription": {
-                        "en": "Visual artist Raija Malka and composer Kaija Saariaho will take over Amos Rex’s exhibition space in a new and experiential way next summer. ",
-                        "fi": "Kuvataiteilija Raija Malka ja säveltäjä Kaija Saariaho täyttävät ensi kesänä Amos Rexin näyttelytilan uudella kokemuksellisella tavalla. ",
-                        "sv": "Bildkonstnären Raija Malka och kompositören Kaija Saariaho fyller Amos Rex utställningsutrymme på ett nytt och experimentellt sätt nästa sommaren.",
-                    },
-                    "startTime": None,
-                    "subEvents": [],
-                    "superEvent": None,
-                    "superEventType": None,
-                },
+                }
             ],
             "meta": {
-                "count": 151775,
+                "count": 1,
                 "next": "https://api.hel.fi/linkedevents/v1/event/?page=2",
                 "previous": None,
             },
@@ -874,7 +803,7 @@ snapshots["test_get_events_with_occurrences 1"] = {
                 },
             ],
             "meta": {
-                "count": 151775,
+                "count": 2,
                 "next": "https://api.hel.fi/linkedevents/v1/event/?page=2",
                 "previous": None,
             },

--- a/graphene_linked_events/utils.py
+++ b/graphene_linked_events/utils.py
@@ -14,12 +14,12 @@ def format_response(response):
     return response.text.replace("@", "internal_")
 
 
-def _json_object_hook(d):
+def json_object_hook(d):
     return namedtuple("X", d.keys())(*d.values())
 
 
 def json2obj(data):
-    return json.loads(data, object_hook=_json_object_hook)
+    return json.loads(data, object_hook=json_object_hook)
 
 
 def format_request(request):

--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -232,7 +232,11 @@ class OccurrenceNode(DjangoObjectType):
     remaining_seats = graphene.Int(required=True)
     seats_taken = graphene.Int(required=True)
     seats_approved = graphene.Int(required=True)
-    linked_event = Field("graphene_linked_events.schema.Event")
+    linked_event = Field(
+        "graphene_linked_events.schema.Event",
+        description="Only use this field in single event query for "
+        + "best performance.",
+    )
 
     def resolve_linked_event(self, info, **kwargs):
         response = api_client.retrieve(

--- a/occurrences/signals.py
+++ b/occurrences/signals.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import List
 
 from anymail.signals import pre_send
@@ -10,7 +11,9 @@ from occurrences.consts import NotificationTemplate
 from occurrences.models import Enrolment, Occurrence, PalvelutarjotinEvent
 from occurrences.utils import send_event_notifications_to_person
 
-from palvelutarjotin.exceptions import ApiUsageError
+from palvelutarjotin.exceptions import ApiUsageError, ObjectDoesNotExistError
+
+logger = logging.getLogger(__name__)
 
 
 def send_event_languages_update(
@@ -37,7 +40,10 @@ def send_event_languages_update(
     # Call API to update event
     result = api_client.update("event", p_event.linked_event_id, json.dumps(event_obj))
 
-    if result.status_code != 200:
+    if result.status_code == 404:
+        raise ObjectDoesNotExistError("Could not find the event from the API")
+
+    elif result.status_code != 200:
         raise ApiUsageError("Cannot update occurrences languages to the event")
 
 
@@ -128,4 +134,10 @@ def update_event_languages_on_occurrence_delete(sender, instance, **kwargs):
         for language in instance.p_event.get_event_languages_from_occurrence()
     ]
     # Send the updated languages to LinkedEvent
-    send_event_languages_update(instance.p_event, event_language_ids)
+    try:
+        send_event_languages_update(instance.p_event, event_language_ids)
+    except ObjectDoesNotExistError as err:
+        logger.warning(
+            "An ObjectDoesNotExistError was raised, but the update process continued,"
+            + "because data is being deleted, not updated. Error: {0}".format(err)
+        )

--- a/occurrences/signals.py
+++ b/occurrences/signals.py
@@ -3,6 +3,7 @@ import logging
 from typing import List
 
 from anymail.signals import pre_send
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
@@ -127,6 +128,13 @@ def update_event_languages_on_occurrence_delete(sender, instance, **kwargs):
     the remaining occurrences languages should be synced to LinkedEvents
     Event languages.
     """
+
+    try:
+        if not hasattr(instance, "p_event"):
+            return
+    except ObjectDoesNotExist:
+        return
+
     # Current languages set to an event.
     # Note that on post_delete, the object will no longer be in the database.
     event_language_ids = [


### PR DESCRIPTION
PT-1134 PT-1131. If LinkedEvents returns an event that does not match on any of our PalvelutarjotinEvent instance, an error was be raised. Now the resolve_events checks all the events in the response if they have a linked PalvelutarjotinEvent in our database.

Added some LinkedEvents API fail proof to occurrence signals.