### PR TITLE
Don't log healthchecks in production.

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,3 +9,5 @@ gid = appuser
 master = 1
 processes = 2
 threads = 2
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:


### PR DESCRIPTION
Healthcheck routes logging spams the production server logs, so they should be ignored. PT-1209.
