### PR TITLE
Recursive rest-client call to fetch all schools and kindergarten pages at once

### DIFF
--- a/servicemap/tests/snapshots/snap_test_api.py
+++ b/servicemap/tests/snapshots/snap_test_api.py
@@ -171,11 +171,7 @@ snapshots["test_list_helsinki_schools_and_kindergartens 1"] = {
                     },
                 },
             ],
-            "meta": {
-                "count": 1019,
-                "next": "https://api.hel.fi/servicemap/v2/unit/?municipality=helsinki&only=name&page=2&service_node=2118%2C868%2C2179%2C1088%2C1257%2C1097",
-                "previous": None,
-            },
+            "meta": {"count": 1019, "next": None, "previous": None},
         }
     }
 }

--- a/servicemap/tests/test_api.py
+++ b/servicemap/tests/test_api.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 GET_SCHOOLS_AND_KINDERGARTENS_LIST_QUERY = """
   query ServicemapSchoolsAndKindergartensList {
     schoolsAndKindergartensList {
@@ -19,8 +21,13 @@ GET_SCHOOLS_AND_KINDERGARTENS_LIST_QUERY = """
   """
 
 
+@patch("servicemap.schema.Query.resolve_schools_and_kindergartens_list")
 def test_list_helsinki_schools_and_kindergartens(
-    api_client, snapshot, mock_get_servicemap_schools_and_kindergartens_data
+    mock_recursive_call,
+    api_client,
+    snapshot,
+    mock_get_servicemap_schools_and_kindergartens_data,
 ):
     executed = api_client.execute(GET_SCHOOLS_AND_KINDERGARTENS_LIST_QUERY)
+    assert mock_recursive_call.call_count == 1
     snapshot.assert_match(executed)

--- a/servicemap/utils.py
+++ b/servicemap/utils.py
@@ -1,5 +1,6 @@
 import json
 from collections import namedtuple
+from urllib.parse import parse_qs, urlsplit
 
 from django.conf import settings
 from servicemap.rest_client import ServicemapApiClient
@@ -17,3 +18,9 @@ def json2obj(data):
 
 def format_request(request):
     return json.dumps(request)
+
+
+def get_params_from_url(url: str):
+    query = urlsplit(url).query
+    params = parse_qs(query)
+    return dict(params)


### PR DESCRIPTION
The service map API response with 1000+ schools and kindergartens, but the max page size is 1000. Because the service map's unit query does not support filtering with a search term and servicemap's search -query does not support filttering with service nodes, we needed a solution to return all the units (1000+) in a single page all at once. This is now achieved by returning all the pages from graphql API (with schoosAndKindergartensList -query). The next page is called recursively when one is available. 

PT-1234 PT-1298 PT-1312.