### PR TITLE
PT-1507 | Only sanitize keys in JSON responses from linked events

### DIFF
--- a/graphene_linked_events/tests/snapshots/snap_test_api.py
+++ b/graphene_linked_events/tests/snapshots/snap_test_api.py
@@ -94,7 +94,7 @@ snapshots["test_get_places 1"] = {
                     "deleted": False,
                     "description": None,
                     "divisions": [{"municipality": None, "ocdId": None}],
-                    "email": "sellonkirjastointernal_espoo.fi",
+                    "email": "sellonkirjasto@espoo.fi",
                     "id": "tprek:15417",
                     "image": 54259,
                     "infoUrl": {
@@ -136,7 +136,7 @@ snapshots["test_get_places 1"] = {
                     "deleted": False,
                     "description": None,
                     "divisions": [{"municipality": None, "ocdId": None}],
-                    "email": "kirjasto.entresseinternal_espoo.fi",
+                    "email": "kirjasto.entresse@espoo.fi",
                     "id": "tprek:15321",
                     "image": 54251,
                     "infoUrl": {
@@ -193,7 +193,7 @@ snapshots["test_get_place 1"] = {
             "deleted": False,
             "description": None,
             "divisions": [{"municipality": None, "ocdId": None}],
-            "email": "sellonkirjastointernal_espoo.fi",
+            "email": "sellonkirjasto@espoo.fi",
             "id": "tprek:15417",
             "image": 54259,
             "infoUrl": {
@@ -323,7 +323,7 @@ snapshots["test_search_places 1"] = {
                     "deleted": False,
                     "description": None,
                     "divisions": [{"municipality": None, "ocdId": None}],
-                    "email": "sellonkirjastointernal_espoo.fi",
+                    "email": "sellonkirjasto@espoo.fi",
                     "id": "tprek:15417",
                     "image": 54259,
                     "infoUrl": {
@@ -365,7 +365,7 @@ snapshots["test_search_places 1"] = {
                     "deleted": False,
                     "description": None,
                     "divisions": [{"municipality": None, "ocdId": None}],
-                    "email": "kirjasto.entresseinternal_espoo.fi",
+                    "email": "kirjasto.entresse@espoo.fi",
                     "id": "tprek:15321",
                     "image": 54251,
                     "infoUrl": {

--- a/graphene_linked_events/tests/snapshots/snap_test_utils.py
+++ b/graphene_linked_events/tests/snapshots/snap_test_utils.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_format_response 1"] = {
+    "data": [
+        {
+            "email": "email1@example.com",
+            "emails": ["email2@example.com", "email3@example.com"],
+            "internal_id": 123,
+        },
+        {
+            "internal_key": "@@@",
+            "internal_keys": [{"internal_key": "value"}, {"key": "@value"}],
+        },
+    ]
+}

--- a/graphene_linked_events/tests/test_utils.py
+++ b/graphene_linked_events/tests/test_utils.py
@@ -1,6 +1,9 @@
+import json
 import math
 
-from graphene_linked_events.utils import bbox_for_coordinates
+import requests
+import responses
+from graphene_linked_events.utils import bbox_for_coordinates, format_response
 
 
 def test_bbox_for_coordinates():
@@ -13,3 +16,23 @@ def test_bbox_for_coordinates():
     assert math.isclose(bbox[1], 60.16764173276239)
     assert math.isclose(bbox[2], 25.00194624440269)
     assert math.isclose(bbox[3], 60.20572118886215)
+
+
+def test_format_response(mocked_responses, snapshot):
+    url = "http://localhost"
+    response_data = {
+        "data": [
+            {
+                "@id": 123,
+                "email": "email1@example.com",
+                "emails": ["email2@example.com", "email3@example.com"],
+            },
+            {"@key": "@@@", "@keys": [{"@key": "value"}, {"key": "@value"}]},
+        ]
+    }
+    mocked_responses.add(responses.GET, url=url, json=response_data)
+
+    response = requests.get(url)
+    formatted = format_response(response)
+
+    snapshot.assert_match(json.loads(formatted))

--- a/graphene_linked_events/utils.py
+++ b/graphene_linked_events/utils.py
@@ -15,8 +15,20 @@ api_client = LinkedEventsApiClient(config=settings.LINKED_EVENTS_API_CONFIG)
 
 
 def format_response(response):
-    # Some fields from api have @prefix that need to be converted
-    return response.text.replace("@", "internal_")
+    """Remove @ sign from API response JSON keys."""
+
+    def format_values(value):
+        if isinstance(value, list):
+            return [format_values(v) for v in value]
+        elif isinstance(value, dict):
+            return {
+                key.replace("@", "internal_"): format_values(value)
+                for key, value in value.items()
+            }
+        return value
+
+    formatted = format_values(json.loads(response.text))
+    return json.dumps(formatted)
 
 
 def json_object_hook(d):


### PR DESCRIPTION
This PR fixes an issues where values in JSON responses were sanitized when only keys were supposed to be sanitized. E.g. email values should not have their `@` turned into `internal_` anymore.