### PR TITLE
Send approval notifications after auto accepted enrolments are handled

### DIFF
--- a/occurrences/tests/notification_template_fixtures.py
+++ b/occurrences/tests/notification_template_fixtures.py
@@ -161,6 +161,28 @@ def notification_template_enrolment_approved_fi():
 
 
 @pytest.fixture
+def notification_sms_template_enrolment_approved_fi():
+    return create_notification_template_in_language(
+        NotificationTemplate.ENROLMENT_APPROVED_SMS,
+        "fi",
+        subject="Enrolment approved SMS FI",
+        body_text=NOTIFICATION_WITH_CUSTOM_MESSAGE_TEXT_FI,
+        body_html=NOTIFICATION_WITH_CUSTOM_MESSAGE_HTML_FI,
+    )
+
+
+@pytest.fixture
+def notification_sms_template_enrolment_approved_en():
+    return create_notification_template_in_language(
+        NotificationTemplate.ENROLMENT_APPROVED_SMS,
+        "en",
+        subject="Enrolment approved SMS EN",
+        body_text=NOTIFICATION_WITH_CUSTOM_MESSAGE_TEXT_EN,
+        body_html=NOTIFICATION_WITH_CUSTOM_MESSAGE_HTML_EN,
+    )
+
+
+@pytest.fixture
 def notification_template_enrolment_declined_en():
     return create_notification_template_in_language(
         NotificationTemplate.ENROLMENT_DECLINED,

--- a/occurrences/tests/snapshots/snap_test_api.py
+++ b/occurrences/tests/snapshots/snap_test_api.py
@@ -723,7 +723,7 @@ snapshots["test_approve_enrolment_with_custom_message 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: qlee@hotmail.com
     Click this link to cancel the enrolment:
-    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTozNV8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTozOV8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
     Custom message: custom message
 """
@@ -737,7 +737,7 @@ snapshots["test_approve_enrolment 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: qlee@hotmail.com
     Click this link to cancel the enrolment:
-    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTozM18yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://beta.kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTozN18yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
 """
 ]

--- a/occurrences/tests/snapshots/snap_test_notifications.py
+++ b/occurrences/tests/snapshots/snap_test_notifications.py
@@ -262,7 +262,38 @@ snapshots["test_decline_enrolment_notification_email_to_multiple_contact_person 
 """,
 ]
 
-snapshots["test_mass_approve_enrolment_mutation 1"] = [
+snapshots["test_send_enrolment_summary_report 1"] = [
+    """no-reply@hel.ninja|['underwoodtracy@roach-cruz.biz']|Enrolment approved FI|
+        Total pending enrolments: 4
+        Total new accepted enrolments: 0
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/aAVEa
+                    Occurrence: #2020-01-13 22:00:00+00:00 (3 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTE=
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTI=
+        """,
+    """no-reply@hel.ninja|['marc09@blackburn.com']|Enrolment approved FI|
+        Total pending enrolments: 3
+        Total new accepted enrolments: 1
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/yJgqk
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/yJgqk/occurrences/T2NjdXJyZW5jZU5vZGU6MjE=
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/yJgqk/occurrences/T2NjdXJyZW5jZU5vZGU6MjI=
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/UQLhZ
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/UQLhZ/occurrences/T2NjdXJyZW5jZU5vZGU6MzE=
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/HIraz
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 new enrolments)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/HIraz/occurrences/T2NjdXJyZW5jZU5vZGU6NDE=
+        """,
+]
+
+snapshots["test_mass_approve_enrolment_mutation[False] 1"] = [
     """no-reply@hel.ninja|['barnettdiana@perry.com']|Enrolment approved FI|
     Event FI: Raija Malka & Kaija Saariaho: Blick
     Extra event info: MTVcH
@@ -329,35 +360,4 @@ snapshots["test_mass_approve_enrolment_mutation 1"] = [
 
     Custom message: Custom message
 """,
-]
-
-snapshots["test_send_enrolment_summary_report 1"] = [
-    """no-reply@hel.ninja|['underwoodtracy@roach-cruz.biz']|Enrolment approved FI|
-        Total pending enrolments: 4
-        Total new accepted enrolments: 0
-            Event name: Raija Malka & Kaija Saariaho: Blick
-            Event link: https://provider.kultus.fi/fi/events/aAVEa
-                    Occurrence: #2020-01-13 22:00:00+00:00 (3 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTE=
-                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTI=
-        """,
-    """no-reply@hel.ninja|['marc09@blackburn.com']|Enrolment approved FI|
-        Total pending enrolments: 3
-        Total new accepted enrolments: 1
-            Event name: Raija Malka & Kaija Saariaho: Blick
-            Event link: https://provider.kultus.fi/fi/events/yJgqk
-                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/yJgqk/occurrences/T2NjdXJyZW5jZU5vZGU6MjE=
-                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/yJgqk/occurrences/T2NjdXJyZW5jZU5vZGU6MjI=
-            Event name: Raija Malka & Kaija Saariaho: Blick
-            Event link: https://provider.kultus.fi/fi/events/UQLhZ
-                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/UQLhZ/occurrences/T2NjdXJyZW5jZU5vZGU6MzE=
-            Event name: Raija Malka & Kaija Saariaho: Blick
-            Event link: https://provider.kultus.fi/fi/events/HIraz
-                    Occurrence: #2020-01-13 22:00:00+00:00 (1 new enrolments)
-                    Link to occurrence: https://provider.kultus.fi/fi/events/HIraz/occurrences/T2NjdXJyZW5jZU5vZGU6NDE=
-        """,
 ]

--- a/occurrences/tests/test_api.py
+++ b/occurrences/tests/test_api.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from django.core import mail
 from django.utils import timezone
 from graphql_relay import to_global_id
+from unittest.mock import patch
 
 from common.tests.utils import (
     assert_mails_match_snapshot,
@@ -1441,8 +1442,18 @@ def test_enrol_invalid_group_size(
 # The auto_acceptance calls Enrolment.approve,
 # so it needs to be tested with both the boolean values.
 @pytest.mark.parametrize("auto_acceptance", [True, False])
+@patch("occurrences.services.notification_service.send_sms")
 def test_enrol_full_people_count_seat_type_occurrence(
-    auto_acceptance, api_client, mock_update_event_data, mock_get_event_data, occurrence
+    mock_send_sms,
+    auto_acceptance,
+    api_client,
+    mock_update_event_data,
+    mock_get_event_data,
+    occurrence,
+    notification_template_enrolment_approved_en,
+    notification_template_enrolment_approved_fi,
+    notification_sms_template_enrolment_approved_en,
+    notification_sms_template_enrolment_approved_fi,
 ):
     study_group_15 = StudyGroupFactory(group_size=15)
     study_group_20 = StudyGroupFactory(group_size=20)
@@ -1486,6 +1497,81 @@ def test_enrol_full_people_count_seat_type_occurrence(
     }
     executed = api_client.execute(ENROL_OCCURRENCE_MUTATION, variables=variables)
     assert_match_error_code(executed, NOT_ENOUGH_CAPACITY_ERROR)
+    assert mock_send_sms.call_count == 0
+    assert len(mail.outbox) == 0
+
+
+# The auto_acceptance calls Enrolment.approve,
+# so it needs to be tested with both the boolean values.
+@pytest.mark.parametrize("auto_acceptance", [True, False])
+@patch("occurrences.services.notification_service.send_sms")
+def test_multi_enrol_full_people_count_seat_type_occurrence(
+    mock_send_sms,
+    auto_acceptance,
+    api_client,
+    mock_update_event_data,
+    mock_get_event_data,
+    occurrence,
+    notification_template_enrolment_approved_en,
+    notification_template_enrolment_approved_fi,
+    notification_sms_template_enrolment_approved_en,
+    notification_sms_template_enrolment_approved_fi,
+):
+    study_group_15 = StudyGroupFactory(group_size=15)
+    study_group_20 = StudyGroupFactory(group_size=20)
+    # Current date froze on 2020-01-04:
+    p_event_1 = PalvelutarjotinEventFactory(
+        enrolment_start=datetime(2020, 1, 3, 0, 0, 0, tzinfo=timezone.now().tzinfo),
+        enrolment_end_days=2,
+        auto_acceptance=auto_acceptance,
+    )
+    valid_occurrence = OccurrenceFactory(
+        start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
+        p_event=p_event_1,
+        min_group_size=10,
+        max_group_size=20,
+        amount_of_seats=100,  # enough for 2 enrolments
+    )
+
+    invalid_occurrence = OccurrenceFactory(
+        start_time=datetime(2020, 1, 6, 0, 0, 0, tzinfo=timezone.now().tzinfo),
+        p_event=p_event_1,
+        min_group_size=10,
+        max_group_size=20,
+        amount_of_seats=34,
+    )
+
+    # After 20 people there are 14 seats left
+    EnrolmentFactory(occurrence=invalid_occurrence, study_group=study_group_20)
+    # Approve the enrolment to reduce the remaining seat
+    # NOTE: currently also the pending enrolments takes seats
+    # Enrolment.objects.first().approve()
+
+    # A group of 15 woul make the event over booked by 1!
+    variables = {
+        "input": {
+            "occurrenceIds": [
+                to_global_id("OccurrenceNode", valid_occurrence.id),
+                to_global_id("OccurrenceNode", invalid_occurrence.id),
+            ],
+            "studyGroup": {
+                "person": {
+                    "id": to_global_id("PersonNode", study_group_15.person.id),
+                    "name": study_group_15.person.name,
+                    "emailAddress": study_group_15.person.email_address,
+                },
+                "unitName": "To be created group",
+                "groupSize": study_group_15.group_size,
+                "groupName": study_group_15.group_name,
+                "studyLevels": [sl.upper() for sl in study_group_15.study_levels.all()],
+                "amountOfAdult": study_group_15.amount_of_adult,
+            },
+        }
+    }
+    executed = api_client.execute(ENROL_OCCURRENCE_MUTATION, variables=variables)
+    assert_match_error_code(executed, NOT_ENOUGH_CAPACITY_ERROR)
+    assert mock_send_sms.call_count == 0
+    assert len(mail.outbox) == 0
 
 
 # The auto_acceptance calls Enrolment.approve,
@@ -3104,7 +3190,7 @@ def test_mass_approve_multi_occurrences_enrolment_mutation(
     assert_match_error_code(executed, API_USAGE_ERROR)
 
 
-def test_approve_multi_occurrences_enrolment(
+def test_approve_multi_occurrences_enrolment_when_multiple_needed_occurrences(
     snapshot, staff_api_client, mock_get_event_data
 ):
     study_group_15 = StudyGroupFactory(group_size=15)


### PR DESCRIPTION
PT-1538. Preventing the SMS notification to be sent when enrolling to multiple occurrences at once and an error occurs after the first enrolment is handled. The transaction should and has rolled back, but the issue was in the SMS sending, which is sent via notification-service and the SMS notification was not rolled back.

This PR is done on the code formatting done in #274 

