### PR TITLE
Improvements to the enrolment reports LinkedEvents-data hydration

### DIFF
--- a/graphene_linked_events/tests/test_api.py
+++ b/graphene_linked_events/tests/test_api.py
@@ -1824,7 +1824,13 @@ query NearbyEvents($placeId: ID, $distance: Float) {
 
 
 def test_nearby_events(
-    api_client, organisation, snapshot, mocked_responses, mock_get_place_data, settings
+    api_client,
+    organisation,
+    snapshot,
+    mocked_responses,
+    mock_get_place_data,
+    mock_get_event_data,
+    settings,
 ):
     """
     Searching for nearby events by place ID should put bbox parameter to the

--- a/occurrences/tests/test_commands.py
+++ b/occurrences/tests/test_commands.py
@@ -9,7 +9,7 @@ from occurrences.models import PalvelutarjotinEvent
 
 
 @pytest.mark.django_db
-def test_delete_retention_period_exceeding_contact_info_command():
+def test_delete_retention_period_exceeding_contact_info_command(mock_get_event_data):
     too_old_1 = timezone.now() - relativedelta(months=24, days=1, minutes=60)
     too_old_2 = timezone.now() - relativedelta(months=24, days=1)
     still_valid_1 = timezone.now() - relativedelta(months=24, days=-1)

--- a/occurrences/tests/test_models.py
+++ b/occurrences/tests/test_models.py
@@ -553,7 +553,9 @@ def test_enrolment_approved_enrolments_by_email(mock_get_event_data):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("delete_via_queryset", (False, True))
-def test_enrolment_and_study_group_person_deletion(delete_via_queryset):
+def test_enrolment_and_study_group_person_deletion(
+    delete_via_queryset, mock_get_event_data
+):
     person = PersonFactory()
     study_group = StudyGroupFactory(person=person)
     enrolment = EnrolmentFactory(study_group=study_group, person=person)
@@ -574,7 +576,7 @@ def test_enrolment_and_study_group_person_deletion(delete_via_queryset):
 
 
 @pytest.mark.django_db
-def test_palvelutarjotin_event_contact_info_deletion():
+def test_palvelutarjotin_event_contact_info_deletion(mock_update_event_data):
     event_1 = PalvelutarjotinEventFactory(contact_person=PersonFactory())
     event_2 = PalvelutarjotinEventFactory(
         contact_email="shouldbedeleted@example.com", contact_phone_number="12345"

--- a/organisations/tests/test_models.py
+++ b/organisations/tests/test_models.py
@@ -133,7 +133,7 @@ def test_user_str():
 
 
 @pytest.mark.django_db
-def test_too_old_personal_data():
+def test_too_old_personal_data(mock_get_event_data):
     too_old = timezone.now() - relativedelta(months=24, days=1)
     still_valid = timezone.now() - relativedelta(months=24, days=-1)
 

--- a/reports/admin.py
+++ b/reports/admin.py
@@ -92,6 +92,17 @@ class HasStudyGroupListFilter(BooleanListFilterBase):
             return queryset.filter(_study_group_id__isnull=True)
 
 
+class HasPublisherListFilter(BooleanListFilterBase):
+    title = _("has publisher")
+    parameter_name = "has-publisher"
+
+    def queryset(self, request, queryset):
+        if self.value() == "True":
+            return queryset.filter(publisher__isnull=False)
+        if self.value() == "False":
+            return queryset.filter(publisher__isnull=True)
+
+
 class IsOutOfSyncListFilter(BooleanListFilterBase):
     title = _("is out of sync with enrolment")
     parameter_name = "is-out-of-sync"
@@ -170,6 +181,7 @@ class EnrolmentReportAdmin(admin.ModelAdmin):
         HasEnrolmentListFilter,
         HasOccurrenceListFilter,
         HasStudyGroupListFilter,
+        HasPublisherListFilter,
     ]
     search_fields = [
         "linked_event_id",

--- a/reports/services.py
+++ b/reports/services.py
@@ -75,25 +75,18 @@ def get_place_json_from_linkedevents(place_id: str):
 
 
 def resolve_place_divisions(place_json) -> Optional[list]:
-    if not place_json:
-        return None
+    # When fetching the event, the division field is under location
+    # NOTE: Some places, e.g helsinki:internet, might not have divisions
     try:
-        # When fetching the event, the division field is under location
-        if "location" in place_json:
-            place_json = place_json["location"]
-        divisions = place_json["divisions"]
-        return [d["ocd_id"] for d in divisions]
-    except KeyError:
+        return [d["ocd_id"] for d in place_json["location"]["divisions"]]
+    except (IndexError, KeyError, TypeError):
         return None
 
 
 def resolve_place_coordinates(place_json) -> Optional[list]:
-    if not place_json:
-        return None
+    # When fetching the event, the position field is under location
+    # NOTE: Some places, e.g helsinki:internet, might not have coordinates
     try:
-        # When fetching the event, the position field is under location
-        if "location" in place_json:
-            place_json = place_json["location"]
-        return place_json["position"]["coordinates"]
-    except KeyError:
+        return place_json["location"]["position"]["coordinates"]
+    except (IndexError, KeyError, TypeError):
         return None


### PR DESCRIPTION
PT-1525 PT-1527.
Add a has publisher filter to the enrolment reports admin page, because with that, it's easy to find the erroneous enrolment report entries and update them (using the admin actions).

Instead of throwing errors, just log them with a logger, so that more data is fetched. Instead of giving up when a first error occurs, we should try to fetch the rest of the info that is given. Also, an improvement to the logging was added, so that it's clearer where the issue is. It should also be noted that not all the places have coordinates, e.g. `helsinki:internet` for internet events, so we should not throw an KeyError in these cases, because it's a valid case.