### PR TITLE
Fix a too long cronjob name

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -163,7 +163,7 @@ jobs:
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
           image_tag:  ${{ github.sha }}
           secret_name: "project-palvelutarjotin-secret"
-          name: "delete-retention-period-exceeding-contact-info"
+          name: "delete-retention-period-exceeding-contacts"
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STABLE }}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
           schedule: '0 3 * * *' # every day 3 AM

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -164,7 +164,7 @@ jobs:
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
           image_tag:  ${{ github.sha }}
           secret_name: "project-staging-palvelutarjotin-secret"
-          name: "delete-retention-period-exceeding-contact-info"
+          name: "delete-retention-period-exceeding-contacts"
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING }}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
           schedule: '0 3 * * *' # every day 3 AM


### PR DESCRIPTION
PT-1619.
The `delete-retention-period-exceeding-contact-info-cronjob`
was a too long name for a cronjob.

```
Error: CronJob.batch
"delete-retention-period-exceeding-contact-info-cronjob"
is invalid: metadata.name:
Invalid value: "delete-retention-period-exceeding-contact-info-cronjob":
must be no more than 52 characters.
```