### PR TITLE
Add support to resolve_place_divisions for divisions not under location

### DIFF
--- a/reports/services.py
+++ b/reports/services.py
@@ -77,8 +77,10 @@ def get_place_json_from_linkedevents(place_id: str):
 def resolve_place_divisions(place_json) -> Optional[list]:
     # When fetching the event, the division field is under location
     # NOTE: Some places, e.g helsinki:internet, might not have divisions
+    if "location" in place_json:
+        place_json = place_json["location"]
     try:
-        return [d["ocd_id"] for d in place_json["location"]["divisions"]]
+        return [d["ocd_id"] for d in place_json["divisions"]]
     except (IndexError, KeyError, TypeError):
         return None
 


### PR DESCRIPTION
### Add support to resolve_place_divisions for divisions not under location

Add support to resolve_place_divisions for the divisions being found directly in place_json["divisions"] and not necessarily always in place_json["location"]["divisions"].

resolve_place_divisions was refactored in
a9d530d1bb342bc20f077f6c5ae9f746257dc4ce but unfortunately the refactoring was done incorrectly.

A similar fix was done to resolve_place_coordinates in 234c113b7c8d7201cbc43f522bb62a5d174709da.

Refs PT-1620 (A similar fix to resolve_place_coordinates)
Refs PT-1525, PT-1527 (resolve_place_divisions was refactored)