### PR TITLE
PT-1569 | update and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
-# Beta Kultus API
+# Kultus API
 
 [![status](https://travis-ci.com/City-of-Helsinki/palvelutarjotin.svg)](https://github.com/City-of-Helsinki/palvelutarjotin)
 [![codecov](https://codecov.io/gh/City-of-Helsinki/palvelutarjotin/branch/develop/graph/badge.svg)](https://codecov.io/gh/City-of-Helsinki/palvelutarjotin)
 
 ## Environments
 
-Production environment:
+### Production environment:
 
-- https://api.hel.fi/kultus-beta/graphql
+- Platta environment: https://kultus.api.hel.fi/graphql
+  - 2023-02-24: This environment is not yet in production use.
+- KuVa environment (Deprecated): https://palvelutarjotin-api.prod.kuva.hel.ninja/graphql
+  - 2023-02-24: This environment is in production use, is deprecated and will be removed in the future.
 
-Testing environment:
+### Testing environment:
 
-- https://palvelutarjotin-api.test.kuva.hel.ninja/graphql
+- Platta environment: https://kultus.api.test.hel.ninja/graphql
+  - 2023-02-24: This environment is in testing use and is the preferred environment for it.
+- KuVa environment (Deprecated): https://palvelutarjotin-api.test.kuva.hel.ninja/graphql
+  - 2023-02-24: This environment is in testing use, is deprecated and will be removed in the future.
 
 ## Development with Docker
 
 1. Copy `docker-compose.env.yaml.example` to `docker-compose.env.yaml` and modify it if needed.
+2. Configure settings, see [Configuration](#configuration)
+3. Run `docker-compose up`
 
-2. Run `docker-compose up`
-
-The project is now running at [localhost:8081](http://localhost:8081)
+The project is now running at http://localhost:8081
 
 ## Development without Docker
 
@@ -27,6 +33,12 @@ Prerequisites:
 
 - PostgreSQL 10
 - Python 3.7
+
+Steps:
+1. Install Python requirements, see [Installing Python requirements](#installing-python-requirements)
+2. Setup database, see [Database](#database)
+3. Configure settings, see [Configuration](#configuration)
+4. Run the server, see [Daily running, Debugging](#daily-running-debugging)
 
 ### Installing Python requirements
 
@@ -52,27 +64,36 @@ Allow user to create test database
 - Set the `DEBUG` environment variable to `1`.
 - Run `python manage.py migrate`
 - Run `python manage.py runserver localhost:8081`
-- The project is now running at [localhost:8081](http://localhost:8081)
+- The project is now running at http://localhost:8081
 
-### Configuration
+## Configuration
 
-1.  You must config Beta Kultus API to integrate with [LinkedEvent API](https://github.com/City-of-Helsinki/linkedevents)
+1.  You must config Kultus API to integrate with [LinkedEvents API](https://github.com/City-of-Helsinki/linkedevents)
 
     Add the following lines to your local `.env` or `docker-compose.env.yaml` if you are using Docker. Take a look
     at the `.env.example` or `docker-compose.env.yaml.example` to see list of required variables
 
     ```python
     LINKED_EVENTS_API_ROOT=<your_linked_event_api_url>          # e.g. http://localhost:8000/v1/
-    LINKED_EVENTS_API_KEY=<your_linked_event_api_key>           # a value from an Api key -field in a LinkedEvent data source.
+    LINKED_EVENTS_API_KEY=<your_linked_event_api_key>           # a value from an Api key -field in a LinkedEvents data source.
     LINKED_EVENTS_DATA_SOURCE=<your_linked_event_data_source>   # e.g. local-kultus
     ```
 
-    - If you are not using local Linked Event, contact LinkedEvent team to provide these information.
+    - If you are not using local Linked Event, contact LinkedEvents team to provide these information.
+      - Or you may find them on Azure DevOps if you have access to [kultus](https://dev.azure.com/City-of-Helsinki/kultus/) there:
+        - From [Kultus API testing variables](https://dev.azure.com/City-of-Helsinki/kultus/_git/kultus-pipelines?path=/variables/kultus-api-testing.yml):
+          - LINKED_EVENTS_API_ROOT=https://api.hel.fi/linkedevents-test/v1/
+          - LINKED_EVENTS_DATA_SOURCE=palvelutarjotin
+        - LINKED_EVENTS_API_KEY secret from:
+          - [Kultus testing keyvault library](https://dev.azure.com/City-of-Helsinki/kultus/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=3458&path=testing-kv)
+            - [Microsoft Azure keyvaults with kultus tag](https://portal.azure.com/#view/HubsExtension/BrowseResourcesWithTag/tagName/project/tagValue/kultus)
+              - [hki-LLvCIhJC-test-kv keyvault secrets](https://portal.azure.com/#@helsinginkaupunki.onmicrosoft.com/resource/subscriptions/5050c890-3cab-451b-b763-ad55ff3688de/resourceGroups/hki-kanslia-shared-we-devtest-rg/providers/Microsoft.KeyVault/vaults/hki-LLvCIhJC-test-kv/secrets)
+                - [LINKED-EVENTS-API-KEY secret](https://portal.azure.com/#@helsinginkaupunki.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/Secret/https://hki-llvcihjc-test-kv.vault.azure.net/secrets/LINKED-EVENTS-API-KEY/93e659586e5145bda88ccde1a9195c66)
 
-    - If you installed LinkedEvent yourself, you can create API_KEY and DATA_SOURCE from your local LinkedEvent admin
+    - If you installed LinkedEvents yourself, you can create API_KEY and DATA_SOURCE from your local LinkedEvents admin
       interface
 
-    - For example: Assuming you are running LinkedEvent API in port 8080 and Kultus API using port 8081, go here to
+    - For example: Assuming you are running LinkedEvents API in port 8080 and Kultus API using port 8081, go here to
       create your DATA_SOURCE and get the API key:
       http://path_to_your_linked_event/admin/events/datasource/add/
 
@@ -82,62 +103,84 @@ Allow user to create test database
       `admin`
     - If you run the Kultus API in your local env, run this command from the project root to create superuser:
 
-    ```
-    ./manage.py add_admin_user -u <username> -p <password> -e <email-address>
-    ```
+      ```
+      ./manage.py add_admin_user -u <username> -p <password> -e <email-address>
+      ```
 
     Then you can use this account to login to Kultus API admin interface at for example http://path_to_your_kultus_api/admin
 
 3.  Create Provider Organisation
 
-    - It's required to create at least one organisation from LE and Kultus. This will be used on Provider UI where user
-      can pick their organisation after login. You'll have to create an organisation in LE, then copy the information
-      to Kultus.
-
-    - If you run the default importer in LE, there will be already some organisations created there, you can use them
-      instead of create your own organisation, but it's recommended to create new one
-    - To create new organisation in LE, visit: http://path_to_your_linked_eventadmin/django_orghierarchy/organization/add/
-    - After creating Organisation in LE, create a similar one in Kultus by visit: http://localhost:8000/admin/organisations/organisation/add/
-      In the `publisher_id` field, use the organisation ID that you got from new LE organsation (e.g ahjo:u4804001010)
+    - At least a single organisation is required to be present in LinkedEvents and in Kultus.
+    - This will be used on Provider UI where user can pick their organisation after login.
+    - If you don't have an organisation in LinkedEvents yet you should create one.
+    - In case you're using an existing [LinkedEvents testing environment](https://api.hel.fi/linkedevents-test/v1/) you
+      can just pick one of the `id` values from the [organisation list](https://api.hel.fi/linkedevents-test/v1/organization/),
+      e.g. [ahjo:u4804001010](https://api.hel.fi/linkedevents-test/v1/organization/ahjo:u4804001010/)
+    - In case you've setup LinkedEvents locally and don't have an existing organisation:
+      - If you run the default importer in LinkedEvents, there will be already some organisations created there, you can use them
+        instead of create your own organisation, but it's recommended to create new one
+      - To create new organisation in LinkedEvents, visit: http://path_to_your_linked_eventadmin/django_orghierarchy/organization/add/
+    - After you have an organisation in LinkedEvents, create a similar one in Kultus at http://localhost:8081/admin/organisations/organisation/add/
+      - Name: \<name of the organisation in LinkedEvents\>, e.g. `Kaupunginkirjasto`
+      - Phone number: Can be left empty
+      - Type: `Provider`
+      - Persons: Can be left empty
+      - Publisher id: \<id of the organisation in LinkedEvents\>, e.g. `ahjo:u4804001010`
 
 4.  Create/update event permissions
 
     - If you only want to work with the GraphQL API without using UI (Teacher UI and Provider UI), when running the
       API in debug mode, there will be a GraphQL client already available at http://path_to_your_kultus_api/graphql
       where you can run your graphql query/mutation. Note that in order to execute mutation or some query requires
-      authentication. In that case, you'll have to login to the admin interface at the beginning of your session
-      , after that you can use that session to run graphql mutation in http://path_to_your_kultus_api/graphql
-    - To be able to manage events via Provider UI, you have to log in the Provider UI first, and create an user there
-      . You'll have to input some information and select the organsation from the organisation list that you created in
+      authentication. In that case, you'll have to login to the admin interface at the beginning of your session,
+      after that you can use that session to run graphql mutation in http://path_to_your_kultus_api/graphql
+    - To be able to manage events via Provider UI, you have to log in the Provider UI first, and create an user there.
+      You'll have to input some information and select the organisation from the organisation list that you created in
       step 2. After that, login to the Kultus-API admin interface using the superuser account, find the new user and
       assign staff permission to this user. After that the user can create/edit events from Provider UI
 
 5.  Configuration needed to use Provider UI and Teacher UI locally:
-    - There are some required variables need to be create and config locally. They are the keyword set ids which will
-      be used to populate the data of some select boxes in the UI. You'll have to create the KeywordSet in LE, add
-      some Keywords to the KeywordSet, then set the KeywordSet ids to `.env` or `docker-compose.env.yaml` depends on
-      what you are using.
-      - Create three keyword sets in LE using this address: http://path_to_your_linked_event/admin/events/keywordset
-        / with the following name: `Kultus Targer Groups`, `Kultus Additional Criteria`, `Kultus Categories`
-      - Add some Keywords to all aboves KeywordSets. There should be some keywords already available in the system if you
-        run the required importers in LinkedEvent. Or you can create new keywords yourself.
-      - Get the ID of those keyword set and put them in `.env` or `docker-compose.env.yaml` depends on your local
-        ```python
-          KEYWORD_SET_CATEGORY_ID=qq:kultus:categories
-          KEYWORD_SET_ADDITIONAL_CRITERIA_ID=qq:kultus:additional_criteria
-          KEYWORD_SET_TARGET_GROUP_ID=qq:kultus:target_groups
-        ```
-6.  (Optional) To use the SMS notification functionality, you have to acquire the API_KEY from [Notification Service API
-    ](https://github.com/City-of-Helsinki/notification-service-api) then add these lines to your local `.env` / `.docker -compose.env.yaml`
+    - These keyword set variables need to be configured in order to populate dropdown boxes' data in the UI:
+      - KEYWORD_SET_CATEGORY_ID
+      - KEYWORD_SET_TARGET_GROUP_ID
+      - KEYWORD_SET_ADDITIONAL_CRITERIA_ID
+    - In case you're using an existing [LinkedEvents testing environment](https://api.hel.fi/linkedevents-test/v1/) you
+      can just use the existing keyword sets from it that don't contain a `qq:` prefix i.e.
+      [kultus:categories](https://api.hel.fi/linkedevents-test/v1/keyword_set/kultus:categories/),
+      [kultus:target_groups](https://api.hel.fi/linkedevents-test/v1/keyword_set/kultus:target_groups/) and
+      [kultus:additional_criteria](https://api.hel.fi/linkedevents-test/v1/keyword_set/kultus:additional_criteria/)
+      by setting the following variables in your `.env` or `docker-compose.env.yaml` file:
+      ```python
+      KEYWORD_SET_CATEGORY_ID=kultus:categories
+      KEYWORD_SET_TARGET_GROUP_ID=kultus:target_groups
+      KEYWORD_SET_ADDITIONAL_CRITERIA_ID=kultus:additional_criteria
+      ```
+    - In case you've setup LinkedEvents locally and don't have existing keyword sets:
+      - You'll have to create the KeywordSet in LinkedEvents, add some Keywords to the KeywordSet, then set the
+        KeywordSet ids to `.env` or `docker-compose.env.yaml` depending on which you are using.
+        - Create three keyword sets in LinkedEvents using this address: http://path_to_your_linked_event/admin/events/keywordset
+          / with the following name: `Kultus Targer Groups`, `Kultus Additional Criteria`, `Kultus Categories`
+        - Add some Keywords to all aboves KeywordSets. There should be some keywords already available in the system if you
+          run the required importers in LinkedEvents. Or you can create new keywords yourself.
+        - Get the IDs of those keyword sets and put them in `.env` or `docker-compose.env.yaml` depending on which you are using
+          ```python
+            KEYWORD_SET_CATEGORY_ID=qq:kultus:categories
+            KEYWORD_SET_ADDITIONAL_CRITERIA_ID=qq:kultus:additional_criteria
+            KEYWORD_SET_TARGET_GROUP_ID=qq:kultus:target_groups
+          ```
+6.  (Optional) To use the SMS notification functionality, you have to acquire the API_KEY from
+    [Notification Service API](https://github.com/City-of-Helsinki/notification-service-api) and
+    then add these lines to your local `.env` / `.docker -compose.env.yaml`:
 
-        ```python
-        NOTIFICATION_SERVICE_API_TOKEN=your_api_key
-        NOTIFICATION_SERVICE_API_URL=notification_service_end_point
-        ```
+    ```python
+    NOTIFICATION_SERVICE_API_TOKEN=your_api_key
+    NOTIFICATION_SERVICE_API_URL=notification_service_end_point
+    ```
 
 7.  (Optional) The notification templates can be imported via
-    a. a Google sheet importer
-    b. a Template file importer
+    - a) Google sheet importer
+    - b) Template file importer
 
     The importer can be used to create and update the notification templates or to check whether the templates are in sync.
     The importer can be used via Django management commands (in notification_importers app) or admin site tools.
@@ -161,7 +204,7 @@ Allow user to create test database
     If a File importer is used, files should be stored in notification_importers app in notification_importers/templates/sms and notification_importers/templates/email folders.
     There is also a naming convention used there. The file name must be given in this pattern [notification_type]-[locale].[html|j2].
 
-8.  (Optional) To offer Kindergartens, schools and colleges from the Servicemap of the Helsinki, the Servicemap API needs to be configured. By default it is using the open data from "https://api.hel.fi/servicemap/v2/unit/" and it should work out of the box.
+8.  (Optional) To offer Kindergartens, schools and colleges from the Servicemap of the Helsinki, the Servicemap API needs to be configured. By default it is using the open data from https://api.hel.fi/servicemap/v2/unit/ and it should work out of the box.
 
 ```python
   env = environ.Env(
@@ -172,7 +215,7 @@ Allow user to create test database
 
 ## API Documentation
 
-To view the API documentation, in DEBUG mode visit: http://localhost:8081/graphql and checkout the `Documentation Explorer` section
+To view the API documentation, in DEBUG mode visit http://localhost:8081/graphql and checkout the `Documentation Explorer` section
 
 ## Keeping Python requirements up to date
 
@@ -229,8 +272,8 @@ _Enrolment report instances are for data utilizing. They are provided through a 
 Enrolment reports should maintain themselves automatically with nightly running cronjobs, but sometimes some manual syncing might be needed. There are some tools for that in enrolment reports admin page:
 
 - Sync unsynced enrolment reports -button can be used to create all the missing enrolment reports and to sync all the enrolment reports out of sync after the date of the last sync done. If the date of the last sync is greater than the updated_at -field's value in an instance that needs the sync, the sync must be done by selecting the instance from admin list view and using the rehydrate -sync actions.
-- Rehydrate the enrolment report instances with LinkedEvent data -action can be used to sync the enrolment report instance with the related enrolment instance. This action also fetches the data from LinkedEvents API, which can lead to some heavy API usage, so please use carefully. All the selected enrolment report instances will be affected.
-- Rehydrate the enrolment report instances without LinkedEvent data -action can be used to sync the enrolment report instance with the related enrolment instance without fetching any data from the LinkedEvent API. This action should be used when the sync needs no data from LiknedEvents, for example when only the enrolment status is wanted to be updated.
+- Rehydrate the enrolment report instances with LinkedEvents data -action can be used to sync the enrolment report instance with the related enrolment instance. This action also fetches the data from LinkedEvents API, which can lead to some heavy API usage, so please use carefully. All the selected enrolment report instances will be affected.
+- Rehydrate the enrolment report instances without LinkedEvents data -action can be used to sync the enrolment report instance with the related enrolment instance without fetching any data from the LinkedEvents API. This action should be used when the sync needs no data from LiknedEvents, for example when only the enrolment status is wanted to be updated.
 
 Enrolment reports can be initialized with the same management command that the cronjob runs: `sync_enrolment_reports`. It will create the missing enrolment reports and sync the enrolment report instances that are out of sync with the related enrolment instance. The `sync_enrolment_reports` command takes in 2 optional parameters:
 


### PR DESCRIPTION
## Description

### docs: update and clean up README 

 - Remove beta from Kultus API as it is in production already
 - Add production environment's Kultus API URL
 - Add info on how to obtain LinkedEvents configuration for testing
 - Fix indentations
 - Don't start text rows with a comma or a dot character
 - Remove unnecessary URL namings where the plain URL works fine and
   can't go out of sync with the name which is almost the same as the
   URL
 - Normalize LE / LinkedEvent / LinkedEvents text usage in README to
   consistently use LinkedEvents

refs PT-1569 (setting up palvelutarjotin & palvelutarjotin-admin)

## Related

[PT-1569](https://helsinkisolutionoffice.atlassian.net/browse/PT-1569)


[PT-1569]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ