### PR TITLE
PT-1650 | chore: switch from KuVa to Platta environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,21 @@
 
 ## Environments
 
-### Production environment:
+Production environment:
 
-- Platta environment: https://kultus.api.hel.fi/graphql
-  - 2023-02-24: This environment is not yet in production use.
-- KuVa environment (Deprecated): https://palvelutarjotin-api.prod.kuva.hel.ninja/graphql
-  - 2023-02-24: This environment is in production use, is deprecated and will be removed in the future.
+- https://kultus.api.hel.fi/graphql
+- Triggered by creation of release-\* tag, e.g. `release-v0.1.0`
+  - Needs to be manually approved in pipeline to be deployed
 
-### Testing environment:
+Staging environment:
 
-- Platta environment: https://kultus.api.test.hel.ninja/graphql
-  - 2023-02-24: This environment is in testing use and is the preferred environment for it.
-- KuVa environment (Deprecated): https://palvelutarjotin-api.test.kuva.hel.ninja/graphql
-  - 2023-02-24: This environment is in testing use, is deprecated and will be removed in the future.
+- https://kultus.api.stage.hel.ninja/graphql
+- Automatically deployed by creation of release-\* tag, e.g. `release-v0.1.0`
+
+Testing environment:
+
+- https://kultus.api.test.hel.ninja/graphql
+- Automatically deployed by any change to master branch
 
 ## Development with Docker
 
@@ -35,6 +37,7 @@ Prerequisites:
 - Python 3.7
 
 Steps:
+
 1. Install Python requirements, see [Installing Python requirements](#installing-python-requirements)
 2. Setup database, see [Database](#database)
 3. Configure settings, see [Configuration](#configuration)
@@ -80,6 +83,7 @@ Allow user to create test database
     ```
 
     - If you are not using local Linked Event, contact LinkedEvents team to provide these information.
+
       - Or you may find them on Azure DevOps if you have access to [kultus](https://dev.azure.com/City-of-Helsinki/kultus/) there:
         - From [Kultus API testing variables](https://dev.azure.com/City-of-Helsinki/kultus/_git/kultus-pipelines?path=/variables/kultus-api-testing.yml):
           - LINKED_EVENTS_API_ROOT=https://api.hel.fi/linkedevents-test/v1/
@@ -179,6 +183,7 @@ Allow user to create test database
     ```
 
 7.  (Optional) The notification templates can be imported via
+
     - a) Google sheet importer
     - b) Template file importer
 

--- a/palvelutarjotin/tests/test_oidc.py
+++ b/palvelutarjotin/tests/test_oidc.py
@@ -31,7 +31,7 @@ class TestOIDC(TestCase):
         # Every test needs access to the request factory.
         self.auth_backend = GraphQLApiTokenAuthentication()
         self.id_token_payload = {
-            "iss": "https://tunnistamo.test.kuva.hel.ninja/openid",
+            "iss": "https://tunnistamo.test.hel.ninja/openid",
             "sub": "sub",
             "aud": "https://api.hel.fi/auth/palvelutarjotin",
             "exp": int(


### PR DESCRIPTION
## Description

### chore: switch from KuVa to Platta environments

refs PT-1650

## Related

[PT-1650](https://helsinkisolutionoffice.atlassian.net/browse/PT-1650)

[PT-1650]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Testing

Tested that all tests pass:
 - `docker-compose up`
 - `docker exec -it kultus-backend bash`
 - `pytest . -vv`