### PR TITLE
fix git REVISION handling when git is unavailable

### DIFF
--- a/palvelutarjotin/settings.py
+++ b/palvelutarjotin/settings.py
@@ -125,7 +125,7 @@ TRANSLATED_SMS_SENDER = env("TRANSLATED_SMS_SENDER")
 try:
     REVISION = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
 except Exception:
-    REVISION = "n/a"
+    REVISION = b"n/a"
 
 sentry_sdk.init(
     dsn=env.str("SENTRY_DSN"),


### PR DESCRIPTION
## Description

### fix: fix git REVISION handling when git is unavailable

docker-compose up --build fails locally with:
```python
Traceback (most recent call last):
...
  File "/app/palvelutarjotin/urls.py", line 12, in <module>
    admin.site.index_title = " ".join([ugettext("Kultus API"),
        get_api_version()])
  File "/app/common/utils.py", line 49, in get_api_version
    return " | ".join((__version__, settings.REVISION.decode("utf-8")))
AttributeError: 'str' object has no attribute 'decode'
```

get_api_version function assumes that REVISION has decode function:
```python
def get_api_version():
    return " | ".join((__version__, settings.REVISION.decode("utf-8")))
```
so it makes sense that REVISION should be bytes, not str.

get_api_version is used to show the git hash of HEAD in the django admin site's title.

https://docs.python.org/3.9/library/subprocess.html documentation for subprocess.check_output says:

> By default, this function will return the data as encoded bytes. The
> actual encoding of the output data may depend on the command being
> invoked, so the decoding to text will often need to be handled at the
> application level.

## Testing

Tested locally in docker on Windows 10, Docker Desktop, WSL2.