### PR TITLE
GDPR person deletion information to EventQueueEnrolment model instances

### DIFF
--- a/organisations/models.py
+++ b/organisations/models.py
@@ -208,11 +208,12 @@ class Person(UUIDPrimaryKeyModel, TimestampedModel):
         return super().delete(*args, **kwargs)
 
     def set_related_objects_person_deleted_at(self):
-        from occurrences.models import Enrolment, StudyGroup
+        from occurrences.models import Enrolment, EventQueueEnrolment, StudyGroup
 
         now = timezone.now()
         Enrolment.objects.filter(person=self).update(person_deleted_at=now)
         StudyGroup.objects.filter(person=self).update(person_deleted_at=now)
+        EventQueueEnrolment.objects.filter(person=self).update(person_deleted_at=now)
 
     def is_editable_by_user(self, user):
         return (

--- a/organisations/tests/snapshots/snap_test_api.py
+++ b/organisations/tests/snapshots/snap_test_api.py
@@ -178,6 +178,53 @@ snapshots["test_organisations_query_type_filter 2"] = {
     }
 }
 
+snapshots["test_person_enrolments 1"] = {
+    "data": {
+        "person": {
+            "enrolmentSet": {
+                "edges": [
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Federal minute paper third item future far power. College information training."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Focus few executive. Movie work organization successful. Fear teacher loss sea just soon food."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Eat design give per kind history ahead. Herself consider fight us claim. Age feeling speech eye."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Tv news management letter. Animal list adult draw staff her."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Second know say former conference carry factor. Natural each difficult special respond positive."
+                            }
+                        }
+                    },
+                ]
+            },
+            "name": "Nancy Conway",
+        }
+    }
+}
+
 snapshots["test_person_query 1"] = {"data": {"person": None}}
 
 snapshots["test_person_query 2"] = {"data": {"person": None}}
@@ -208,6 +255,84 @@ snapshots["test_person_query 4"] = {
                 "COmRVJDOXAmjOnQtrkEQ",
                 "KcMIonuxkiABRtJfcwOr",
             ],
+        }
+    }
+}
+
+snapshots["test_person_queued_enrolments 1"] = {
+    "data": {
+        "person": {
+            "eventqueueenrolmentSet": {
+                "edges": [
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Anyone conference should feel produce wife. Wonder pressure stage research direction forget list."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Tonight use form simply trade minute production."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Policy parent toward apply see on send in. Full three especially card animal recognize stock."
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "studyGroup": {
+                                "groupName": "Hotel event already college. Ok court type hit."
+                            }
+                        }
+                    },
+                    {"node": {"studyGroup": {"groupName": "Six feel real fast."}}},
+                ]
+            },
+            "name": "Nancy Conway",
+        }
+    }
+}
+
+snapshots["test_person_study_groups 1"] = {
+    "data": {
+        "person": {
+            "name": "Nancy Conway",
+            "studygroupSet": {
+                "edges": [
+                    {
+                        "node": {
+                            "groupName": "Second know say former conference carry factor. Natural each difficult special respond positive."
+                        }
+                    },
+                    {
+                        "node": {
+                            "groupName": "Tv news management letter. Animal list adult draw staff her."
+                        }
+                    },
+                    {
+                        "node": {
+                            "groupName": "Eat design give per kind history ahead. Herself consider fight us claim. Age feeling speech eye."
+                        }
+                    },
+                    {
+                        "node": {
+                            "groupName": "Focus few executive. Movie work organization successful. Fear teacher loss sea just soon food."
+                        }
+                    },
+                    {
+                        "node": {
+                            "groupName": "Federal minute paper third item future far power. College information training."
+                        }
+                    },
+                ]
+            },
         }
     }
 }


### PR DESCRIPTION
PT-1651 PT-1660.

1. Added some missing tests for Person
2. Added EventQueueEnrolments to the Django admin site
3. Show the person delete at -info in EventQueueEnrolment admin
4. Set the person delete at -info when a related person is deleted