### PR TITLE
Add PickEnrolmentFromQueueMutation

### DIFF
--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -718,6 +718,16 @@ class EventQueueEnrolment(EnrolmentBase):
             else self.STATUS_HAS_NO_ENROLMENTS
         )
 
+    def create_enrolment(self, occurrence: Occurrence):
+        enrolment = Enrolment(
+            occurrence=occurrence,
+            study_group=self.study_group,
+            notification_type=self.notification_type,
+            person=self.person,
+        )
+        enrolment.save()
+        return enrolment
+
 
 class Enrolment(EnrolmentBase):
     STATUS_APPROVED = "approved"

--- a/occurrences/tests/mutations.py
+++ b/occurrences/tests/mutations.py
@@ -399,3 +399,21 @@ mutation unenrolEventQueue($input: UnenrolEventQueueMutationInput!){
   }
 }
 """
+
+PICK_ENROLMENT_FROM_QUEUE_MUTATION = """
+mutation PickEnrolmentFromQueueMutation($input: PickEnrolmentFromQueueMutationInput!){
+  pickEnrolmentFromQueue(input: $input){
+    enrolment{
+      studyGroup{
+        groupName
+      }
+      notificationType
+      status
+      person{
+        name
+        emailAddress
+      }
+    }
+  }
+}
+"""

--- a/occurrences/tests/snapshots/snap_test_api.py
+++ b/occurrences/tests/snapshots/snap_test_api.py
@@ -1994,6 +1994,24 @@ snapshots["test_occurrences_query 1"] = {
     }
 }
 
+snapshots["test_pick_enrolment_from_queue 1"] = {
+    "data": {
+        "pickEnrolmentFromQueue": {
+            "enrolment": {
+                "notificationType": "EMAIL",
+                "person": {
+                    "emailAddress": "lisawallace@example.com",
+                    "name": "Ashley Jones",
+                },
+                "status": "PENDING",
+                "studyGroup": {
+                    "groupName": "Decade address have turn serve me every traditional. Sound describe risk newspaper reflect four."
+                },
+            }
+        }
+    }
+}
+
 snapshots["test_study_level_query 1"] = {
     "data": {
         "studyLevel": {

--- a/occurrences/tests/test_models.py
+++ b/occurrences/tests/test_models.py
@@ -271,13 +271,14 @@ def test_creating_enrolment_from_event_queue_enrolment(mock_get_event_data):
     The event queue enrolment can be easily used as a base
     for an enrolment to an occurrence.
     """
+    occurrence = OccurrenceFactory()
     queue = EventQueueEnrolmentFactory()
-    occurrence = OccurrenceFactory(p_event=queue.p_event)
-    enrolment = Enrolment(
-        occurrence=occurrence, study_group=queue.study_group, person=queue.person
-    )
-    enrolment.save()
+    enrolment = queue.create_enrolment(occurrence)
     assert Enrolment.objects.count() == 1
+    assert enrolment.occurrence == occurrence
+    assert enrolment.study_group == queue.study_group
+    assert enrolment.person == queue.person
+    assert enrolment.notification_type == queue.notification_type
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
PT-1651 PT-1670.

The EventQueueEnrolments are meant to be transformable as Enrolments when the occurrence information is added to them. The old plan was to use the EnrolOccurrenceMutation to transform them, but when implementing the client for the mutation, it was clear that it was too complicated, since the EnrolOccurrenceMutation needs a new study group instance as an input. With this PickEnrolmentFromQueueMutation the ids can be used and the exact same study group will be used when the new enrolment is created.