### PR TITLE
Filter events with contact info query

### DIFF
--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -81,6 +81,18 @@ class PalvelutarjotinEventQueryset(TranslatableQuerySet):
             )
         )
 
+    def filter_with_contact_info(self, person: Person):
+        if not person.email_address and not person.phone_number:
+            raise ValueError(
+                "The person must have at least an email address or a phone number."
+            )
+        return self.filter(
+            Q(contact_person__email_address=person.email_address)
+            | Q(contact_person__phone_number=person.phone_number)
+            | Q(contact_email=person.email_address)
+            | Q(contact_phone_number=person.phone_number)
+        ).order_by("contact_person", "contact_email", "contact_phone_number")
+
     def delete_contact_info(self, now=None):
         if not now:
             now = timezone.now()


### PR DESCRIPTION
PT-1213.

This pull request has been done as a base work for [PT-1213](https://helsinkisolutionoffice.atlassian.net/browse/PT-1213). The ticket was but on hold, because the amount of work was not giving enough.

However, the feature that was already implemented, could be good as so for some administrative use. It would be easier to find events related to some persons, for example when finding some GDPR related data.

Also, some refactoring (code splitting) is done to make the code more clear. The refactoring effects only to events query.

[PT-1213]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ