### PR TITLE
feat: event queue enrolment counts are included in the enrolment summary

### DIFF
--- a/notification_importers/templates/email/enrolment_summary_report-en.html
+++ b/notification_importers/templates/email/enrolment_summary_report-en.html
@@ -418,6 +418,7 @@
                                     <ul>
                                       <li>Automatically approved: {{ total_new_enrolments }}</li>
                                       <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>New queued event enrolments: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Check these:</p>
@@ -428,6 +429,7 @@
                                           item.event.name.en is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>New queued enrolments: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}

--- a/notification_importers/templates/email/enrolment_summary_report-fi.html
+++ b/notification_importers/templates/email/enrolment_summary_report-fi.html
@@ -418,6 +418,7 @@
                                     <ul>
                                       <li>Automaattisesti hyväksyttyjä: {{ total_new_enrolments }}</li>
                                       <li>Hyväksymättä: {{ total_pending_enrolments }}</li>
+                                      <li>Uusia jonoilmoittautumisia: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Käy katsomassa nämä:</p>
@@ -428,6 +429,7 @@
                                           item.event.name.fi is defined else item.event.name.en if item.event.name.en is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>Uusia ilmoittautumisia jonossa: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}

--- a/notification_importers/templates/email/enrolment_summary_report-sv.html
+++ b/notification_importers/templates/email/enrolment_summary_report-sv.html
@@ -417,17 +417,19 @@
                                     <p>Här är de senaste 24 timmarna av registreringar</p>
                                     <ul>
                                       <li>Godkänd automatiskt: {{ total_new_enrolments }}</li>
-                                      <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>Totalt väntande registreringar: {{ total_pending_enrolments }}</li>
+                                      <li>Nya köade eventregistreringar: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Glöm ej att kolla dessa:</p>
                                     <ul>
                                       {% for item in report %}
-                                      <li>Event: <a
+                                      <li>Evenemang: <a
                                           href="{{ item.p_event.get_link_to_provider_ui() }}">{{item.event.name.sv if
                                           item.event.name.sv is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.en}}</a>
                                         <ul>
+                                          <li>Nya köade registreringar: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}

--- a/notification_importers/tests/snapshots/snap_test_notification_file_importer.py
+++ b/notification_importers/tests/snapshots/snap_test_notification_file_importer.py
@@ -4954,6 +4954,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <ul>
                                       <li>Automaattisesti hyväksyttyjä: {{ total_new_enrolments }}</li>
                                       <li>Hyväksymättä: {{ total_pending_enrolments }}</li>
+                                      <li>Uusia jonoilmoittautumisia: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Käy katsomassa nämä:</p>
@@ -4964,6 +4965,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                           item.event.name.fi is defined else item.event.name.en if item.event.name.en is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>Uusia ilmoittautumisia jonossa: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}
@@ -5428,6 +5430,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <ul>
                                       <li>Automatically approved: {{ total_new_enrolments }}</li>
                                       <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>New queued event enrolments: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Check these:</p>
@@ -5438,6 +5441,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                           item.event.name.en is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>New queued enrolments: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}
@@ -5902,17 +5906,19 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <p>Här är de senaste 24 timmarna av registreringar</p>
                                     <ul>
                                       <li>Godkänd automatiskt: {{ total_new_enrolments }}</li>
-                                      <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>Totalt väntande registreringar: {{ total_pending_enrolments }}</li>
+                                      <li>Nya köade eventregistreringar: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Glöm ej att kolla dessa:</p>
                                     <ul>
                                       {% for item in report %}
-                                      <li>Event: <a
+                                      <li>Evenemang: <a
                                           href="{{ item.p_event.get_link_to_provider_ui() }}">{{item.event.name.sv if
                                           item.event.name.sv is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.en}}</a>
                                         <ul>
+                                          <li>Nya köade registreringar: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}
@@ -18330,6 +18336,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <ul>
                                       <li>Automaattisesti hyväksyttyjä: {{ total_new_enrolments }}</li>
                                       <li>Hyväksymättä: {{ total_pending_enrolments }}</li>
+                                      <li>Uusia jonoilmoittautumisia: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Käy katsomassa nämä:</p>
@@ -18340,6 +18347,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                           item.event.name.fi is defined else item.event.name.en if item.event.name.en is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>Uusia ilmoittautumisia jonossa: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}
@@ -18804,6 +18812,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <ul>
                                       <li>Automatically approved: {{ total_new_enrolments }}</li>
                                       <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>New queued event enrolments: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Check these:</p>
@@ -18814,6 +18823,7 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                           item.event.name.en is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.sv}}</a>
                                         <ul>
+                                          <li>New queued enrolments: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}
@@ -19278,17 +19288,19 @@ enrolment_summary_report|Ilmoittautumisen yhteenvetoraportti|Enrolment summary r
                                     <p>Här är de senaste 24 timmarna av registreringar</p>
                                     <ul>
                                       <li>Godkänd automatiskt: {{ total_new_enrolments }}</li>
-                                      <li>Pending enrolments: {{ total_pending_enrolments }}</li>
+                                      <li>Totalt väntande registreringar: {{ total_pending_enrolments }}</li>
+                                      <li>Nya köade eventregistreringar: {{ total_new_queued_enrolments }}</li>
                                     </ul>
 
                                     <p>Glöm ej att kolla dessa:</p>
                                     <ul>
                                       {% for item in report %}
-                                      <li>Event: <a
+                                      <li>Evenemang: <a
                                           href="{{ item.p_event.get_link_to_provider_ui() }}">{{item.event.name.sv if
                                           item.event.name.sv is defined else item.event.name.fi if item.event.name.fi is
                                           defined else item.event.name.en}}</a>
                                         <ul>
+                                          <li>Nya köade registreringar: {{item.queued_enrolments | length}}</li>
                                           {% for occurrence in item.occurrences %}
                                           <li>
                                             {% if item.p_event.auto_acceptance %}

--- a/occurrences/management/commands/send_enrolment_summary.py
+++ b/occurrences/management/commands/send_enrolment_summary.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from occurrences.models import Enrolment
+from occurrences.notification_services import (
+    send_enrolment_summary_report_to_providers_from_days,
+)
 
 
 class Command(BaseCommand):
@@ -9,4 +11,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         if settings.ENABLE_SUMMARY_REPORT:
-            Enrolment.send_enrolment_summary_report_to_providers()
+            send_enrolment_summary_report_to_providers_from_days(days=1)

--- a/occurrences/notifications.py
+++ b/occurrences/notifications.py
@@ -6,6 +6,7 @@ from graphene_linked_events.tests.mock_data import EVENT_DATA
 from occurrences.consts import NotificationTemplate
 from occurrences.factories import (
     EnrolmentFactory,
+    EventQueueEnrolmentFactory,
     OccurrenceFactory,
     PalvelutarjotinEventFactory,
     StudyGroupFactory,
@@ -37,7 +38,8 @@ person = PersonFactory.build()
 study_group = StudyGroupFactory.build(person=person)
 p_event = PalvelutarjotinEventFactory.build()
 occurrence = OccurrenceFactory.build(id=1, p_event=p_event)
-enrolment = EnrolmentFactory.build()
+enrolment = EnrolmentFactory.build(occurrence=occurrence)
+queued_enrolment = EventQueueEnrolmentFactory.build(p_event=p_event)
 
 DEFAULT_DUMMY_CONTEXT = {
     "preview_mode": False,
@@ -46,6 +48,7 @@ DEFAULT_DUMMY_CONTEXT = {
     "occurrence": occurrence,
     "event": EVENT_DATA,
     "enrolment": enrolment,
+    "queued_enrolment": queued_enrolment,
     "custom_message": "custom_message",
     "trans": lambda field_translation_map: field_translation_map["fi"],
 }
@@ -68,10 +71,16 @@ dummy_context.update(
         NotificationTemplate.OCCURRENCE_UPCOMING_SMS: DEFAULT_DUMMY_CONTEXT,
         NotificationTemplate.ENROLMENT_SUMMARY_REPORT: {
             "report": [
-                {"event": EVENT_DATA, "p_event": p_event, "occurrences": [occurrence]}
+                {
+                    "event": EVENT_DATA,
+                    "p_event": p_event,
+                    "occurrences": [occurrence],
+                    "queued_enrolments": [queued_enrolment],
+                }
             ],
             "total_pending_enrolments": 1,
             "total_new_enrolments": 2,
+            "total_new_queued_enrolments": 1,
         },
     }
 )

--- a/occurrences/tests/snapshots/snap_test_notifications.py
+++ b/occurrences/tests/snapshots/snap_test_notifications.py
@@ -6,6 +6,255 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_approve_enrolment_notification_email 1"] = [
+    """no-reply@hel.ninja|['hutchinsonrachel@example.org']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: ihlLy
+    Study group: Skin watch media. Condition like lay still bar. From daughter order stay sign discover eight.
+    Occurrence: 09.05.1995 16.24
+    Person: hutchinsonrachel@example.org
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: custom message
+"""
+]
+
+snapshots["test_cancel_enrolment_notification_email 1"] = [
+    """no-reply@hel.ninja|['gtorres@example.com']|Enrolment cancellation confirmation FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: gtorres@example.com
+
+    Custom message: custom message
+"""
+]
+
+snapshots["test_cancelled_enrolment_notification_email 1"] = [
+    """no-reply@hel.ninja|['email_me@dommain.com']|Enrolment cancelled FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Let join might player example environment. Then offer organization model.
+    Occurrence: 12.12.2013 06.37
+    Person: email_me@dommain.com
+
+    Custom message: custom message
+"""
+]
+
+snapshots["test_decline_enrolment_notification_email 1"] = [
+    """no-reply@hel.ninja|['gtorres@example.com']|Enrolment declined FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: gtorres@example.com
+
+    Custom message: custom message
+"""
+]
+
+snapshots["test_decline_enrolment_notification_email_to_multiple_contact_person 1"] = [
+    """no-reply@hel.ninja|['gtorres@example.com']|Enrolment declined FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: gtorres@example.com
+
+    Custom message: custom message
+"""
+]
+
+snapshots["test_decline_enrolment_notification_email_to_multiple_contact_person 2"] = [
+    """no-reply@hel.ninja|['gtorres@example.com']|Enrolment declined FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: gtorres@example.com
+
+    Custom message: custom message
+""",
+    """no-reply@hel.ninja|['oadams@example.org']|Enrolment declined FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: WREov
+    Study group: Real fast authority. Security American future quality result let.
+    Occurrence: 14.05.1994 23.52
+    Person: oadams@example.org
+
+    Custom message: custom message
+""",
+    """no-reply@hel.ninja|['amandamurphy@example.org']|Enrolment declined FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: WREov
+    Study group: Real fast authority. Security American future quality result let.
+    Occurrence: 14.05.1994 23.52
+    Person: amandamurphy@example.org
+
+    Custom message: custom message
+""",
+]
+
+snapshots["test_local_time_notification[tz0] 1"] = [
+    """no-reply@hel.ninja|['hutchinsonrachel@example.org']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: eAhkM
+    Study group: Skin watch media. Condition like lay still bar. From daughter order stay sign discover eight.
+    Occurrence: 04.01.2020 00.00
+    Person: hutchinsonrachel@example.org
+"""
+]
+
+snapshots["test_local_time_notification[tz1] 1"] = [
+    """no-reply@hel.ninja|['hutchinsonrachel@example.org']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: eAhkM
+    Study group: Skin watch media. Condition like lay still bar. From daughter order stay sign discover eight.
+    Occurrence: 04.01.2020 00.00
+    Person: hutchinsonrachel@example.org
+"""
+]
+
+snapshots["test_local_time_notification[tz2] 1"] = [
+    """no-reply@hel.ninja|['hutchinsonrachel@example.org']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: eAhkM
+    Study group: Skin watch media. Condition like lay still bar. From daughter order stay sign discover eight.
+    Occurrence: 04.01.2020 00.00
+    Person: hutchinsonrachel@example.org
+"""
+]
+
+snapshots["test_mass_approve_enrolment_mutation[False] 1"] = [
+    """no-reply@hel.ninja|['brendasanchez@example.com']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Work early property your stage receive. Determine sort under car.
+    Occurrence: 02.08.1988 10.00
+    Person: brendasanchez@example.com
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+    """no-reply@hel.ninja|['operry@example.com']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Work early property your stage receive. Determine sort under car.
+    Occurrence: 02.08.1988 10.00
+    Person: operry@example.com
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+    """no-reply@hel.ninja|['michael98@example.net']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Body hard community somebody quality better majority. Artist alone lawyer might.
+    Occurrence: 02.08.1988 10.00
+    Person: michael98@example.net
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+    """no-reply@hel.ninja|['acontreras@example.net']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Body hard community somebody quality better majority. Artist alone lawyer might.
+    Occurrence: 02.08.1988 10.00
+    Person: acontreras@example.net
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+    """no-reply@hel.ninja|['nhuffman@example.net']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Opportunity care ready chair summer structure professional. Short food tree kid meet art space.
+    Occurrence: 02.08.1988 10.00
+    Person: nhuffman@example.net
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+    """no-reply@hel.ninja|['andrewfox@example.net']|Enrolment approved FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: bkihg
+    Study group: Opportunity care ready chair summer structure professional. Short food tree kid meet art space.
+    Occurrence: 02.08.1988 10.00
+    Person: andrewfox@example.net
+    Click this link to cancel the enrolment:
+    https://kultus.fi/fi/enrolments/cancel/mock-enrolment-unique-id-abc123xyz456
+
+    Custom message: Custom message
+""",
+]
+
+snapshots["test_occurrence_enrolment_notifications_email_only 1"] = [
+    """no-reply@hel.ninja|['gtorres@example.com']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: gtorres@example.com
+""",
+    """no-reply@hel.ninja|['gtorres@example.com']|Occurrence unenrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.57
+    Person: gtorres@example.com
+""",
+    """no-reply@hel.ninja|['gtorres@example.com']|Occurrence enrolment EN|
+    Event EN: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Real fast authority. Security American future quality result let.
+    Occurrence: 12.12.2013 06.37
+    Person: amandamurphy@example.org""",
+    """no-reply@hel.ninja|['gtorres@example.com']|Occurrence unenrolment EN|
+    Event EN: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Real fast authority. Security American future quality result let.
+    Occurrence: 12.12.2013 06.57
+    Person: amandamurphy@example.org""",
+]
+
+snapshots["test_occurrence_enrolment_notifications_to_contact_person 1"] = [
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence enrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.37
+    Person: email_me@dommain.com
+""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence unenrolment FI|
+    Event FI: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Tough plant traditional after born up always. Return student light a point charge.
+    Occurrence: 12.12.2013 06.57
+    Person: email_me@dommain.com
+""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence enrolment EN|
+    Event EN: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Stay huge break. Far ten bar ask alone them yeah.
+    Occurrence: 12.12.2013 06.37
+    Person: do_not_email_me@domain.com""",
+    """no-reply@hel.ninja|['email_me@dommain.com']|Occurrence unenrolment EN|
+    Event EN: Raija Malka & Kaija Saariaho: Blick
+    Extra event info: zVxeo
+    Study group: Stay huge break. Far ten bar ask alone them yeah.
+    Occurrence: 12.12.2013 06.57
+    Person: do_not_email_me@domain.com""",
+]
+
 snapshots["test_only_send_approved_notification[False] 1"] = [
     """no-reply@hel.ninja|['hutchinsonrachel@example.org']|Occurrence enrolment FI|
     Event FI: Raija Malka & Kaija Saariaho: Blick
@@ -39,4 +288,35 @@ snapshots["test_only_send_approved_notification[True] 1"] = [
     https://kultus.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZToxXzIwMjAtMDEtMDQgMDA6MDA6MDArMDA6MDA=
 
 """
+]
+
+snapshots["test_send_enrolment_summary_report 1"] = [
+    """no-reply@hel.ninja|['dsellers@example.net']|Enrolment approved FI|
+        Total pending enrolments: 4
+        Total new accepted enrolments: 0
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/aAVEa
+                    Occurrence: #2020-01-13 22:00:00+00:00 (3 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTE=
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/aAVEa/occurrences/T2NjdXJyZW5jZU5vZGU6MTI=
+        """,
+    """no-reply@hel.ninja|['seanyoung@example.net']|Enrolment approved FI|
+        Total pending enrolments: 3
+        Total new accepted enrolments: 1
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/tMVlt
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 new enrolments)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/tMVlt/occurrences/T2NjdXJyZW5jZU5vZGU6NDE=
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/nvAIl
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/nvAIl/occurrences/T2NjdXJyZW5jZU5vZGU6MjE=
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/nvAIl/occurrences/T2NjdXJyZW5jZU5vZGU6MjI=
+            Event name: Raija Malka & Kaija Saariaho: Blick
+            Event link: https://provider.kultus.fi/fi/events/HjoSH
+                    Occurrence: #2020-01-13 22:00:00+00:00 (1 pending)
+                    Link to occurrence: https://provider.kultus.fi/fi/events/HjoSH/occurrences/T2NjdXJyZW5jZU5vZGU6MzE=
+        """,
 ]


### PR DESCRIPTION
PT-1717.

The enrolment summary now contains
1. a total new event queue enrolment count
2. event specific new queue enrolment count
Both of the new infos are only from events that are related to the recipient.

The `send_enrolment_summary_report_to_providers` is now removed
from the Enrolment model as a needless function.
It is replaced with an util that handles the both: the event specific
event queue enrolments and the event occurrence specific enrolments.

<img width="590" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin/assets/389204/65b4f3c0-8e76-42bd-b3d9-38ecb305b607">

<img width="600" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin/assets/389204/ea1ac7c7-3e3d-421e-96c9-3fc0037829b2">

<img width="603" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin/assets/389204/a64ad15d-a2af-44d5-a542-7dbd321d7f22">

NOTE: The preview is viewable in `/admin/django_ilmoitin/notificationtemplate/` -change form