### PR TITLE
fix: oidc audience env variable was always read as a string

### DIFF
--- a/palvelutarjotin/settings.py
+++ b/palvelutarjotin/settings.py
@@ -257,7 +257,7 @@ OIDC_API_TOKEN_AUTH = {
     # RequestJWTAuthentication supports multiple acceptable audiences,
     # so this setting can also be a list of strings.
     # This setting is required.
-    "AUDIENCE": env.str("TOKEN_AUTH_ACCEPTED_AUDIENCE"),
+    "AUDIENCE": env.list("TOKEN_AUTH_ACCEPTED_AUDIENCE"),
     # Who we trust to sign the tokens. The library will request the
     # public signature keys from standard locations below this URL.
     # RequestJWTAuthentication supports multiple issuers, so this

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ django-axes==5.41.1
     # via -r requirements.in
 django-cors-headers==3.14.0
     # via -r requirements.in
-django-environ==0.10.0
+django-environ==0.11.2
     # via -r requirements.in
 django-filter==23.1
     # via -r requirements.in


### PR DESCRIPTION
PT-1758 PT-1763.

Upgraded the django-environ.