### PR TITLE
ci: increase uwsgi buffer size

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -18,3 +18,5 @@ processes = 2
 threads = 2
 route = ^/readiness$ donotlog:
 route = ^/healthz$ donotlog:
+
+buffer-size = 65535 # Allow bigger requests that includes a big list of AD-groups. Default is 4096.


### PR DESCRIPTION
PT-1758 PT-1763.

The Entra ID login needs a bigger buffer size because there are so many groups linked to the user.