### PR TITLE
fix: user deleted via GDPR API should not be relinkable to profile

### DIFF
--- a/gdpr/service.py
+++ b/gdpr/service.py
@@ -57,6 +57,7 @@ def clear_data(user: "UserType", dry_run: bool) -> Optional[ErrorResponse]:
     logger.info(f"GDPR data clear called for user '{user.uuid}'.")
     user.clear_gdpr_sensitive_data_fields()
     try:
+        user.delete_related_p_event_contact_info()
         user.person.delete()
         # person = user.person
         # person.clear_gdpr_sensitive_data_fields()

--- a/gdpr/tests/snapshots/snap_test_gdpr_api.py
+++ b/gdpr/tests/snapshots/snap_test_gdpr_api.py
@@ -136,14 +136,11 @@ snapshots[
 snapshots["test_get_profile_data_from_gdpr_api[Complex User, Deleted] 1"] = {
     "children": [
         {"key": "UUID", "value": "26850000-2e85-11ea-b347-acde48001122"},
-        {
-            "key": "USERNAME",
-            "value": "gdpr:cleared-26850000-2e85-11ea-b347-acde48001122",
-        },
+        {"key": "USERNAME", "value": "u-e2cqaaboqui6vm2hvtpeqaarei"},
         {"key": "FIRST_NAME", "value": ""},
         {"key": "LAST_NAME", "value": ""},
         {"key": "EMAIL", "value": ""},
-        {"key": "LAST_LOGIN", "value": "2020-01-04T00:00:00+00:00"},
+        {"key": "LAST_LOGIN", "value": None},
         {"key": "DATE_JOINED", "value": "2020-01-04T00:00:00+00:00"},
     ],
     "key": "USER",
@@ -607,14 +604,11 @@ Enjoy office water those notice medical. Already name likely behind mission netw
 snapshots["test_get_profile_data_from_gdpr_api[Simple User, Deleted] 1"] = {
     "children": [
         {"key": "UUID", "value": "26850000-2e85-11ea-b347-acde48001122"},
-        {
-            "key": "USERNAME",
-            "value": "gdpr:cleared-26850000-2e85-11ea-b347-acde48001122",
-        },
+        {"key": "USERNAME", "value": "u-e2cqaaboqui6vm2hvtpeqaarei"},
         {"key": "FIRST_NAME", "value": ""},
         {"key": "LAST_NAME", "value": ""},
         {"key": "EMAIL", "value": ""},
-        {"key": "LAST_LOGIN", "value": "2020-01-04T00:00:00+00:00"},
+        {"key": "LAST_LOGIN", "value": None},
         {"key": "DATE_JOINED", "value": "2020-01-04T00:00:00+00:00"},
     ],
     "key": "USER",

--- a/gdpr/tests/test_gdpr_api.py
+++ b/gdpr/tests/test_gdpr_api.py
@@ -61,13 +61,19 @@ def _request_gdpr_delete(
         )
 
 
-def _assert_clear(user, original_password: Optional[str] = None):
+def _assert_clear(
+    user,
+    original_password: Optional[str] = None,
+    original_uuid: Optional[uuid.UUID] = None,
+):
     if original_password:
         assert user.password != original_password
+    if original_uuid:
+        assert user.uuid != original_uuid
     assert user.first_name == ""
     assert user.last_name == ""
     assert user.email == ""
-    assert user.username == f"{CLEARED_VALUE}-{user.uuid}"
+    assert user.username == f"{CLEARED_VALUE}-{original_uuid}"
 
 
 def _delete_user(user, params):
@@ -128,9 +134,10 @@ def _get_db_table_counts_of_person_related_tables():
 @pytest.mark.django_db
 def test_clear_data_service(user):
     original_password = user.password
+    original_uuid = user.uuid
     clear_data(user=user, dry_run=False)
     user.refresh_from_db()
-    _assert_clear(user, original_password)
+    _assert_clear(user, original_password, original_uuid)
 
 
 @pytest.mark.django_db
@@ -148,17 +155,19 @@ def test_gdpr_api_delete_profile_dry_run(true_value, user, key):
 @pytest.mark.parametrize("key", ["data", "query_params"])
 def test_gdpr_api_delete_profile(false_value, user, key):
     original_password = user.password
+    original_uuid = user.uuid
     _delete_user(user, {key: {"dry_run": false_value}})
     user.refresh_from_db()
-    _assert_clear(user, original_password)
+    _assert_clear(user, original_password, original_uuid)
 
 
 @pytest.mark.django_db
 def test_gdpr_api_delete_profile_no_params(user):
     original_password = user.password
+    original_uuid = user.uuid
     _delete_user(user, {})
     user.refresh_from_db()
-    _assert_clear(user, original_password)
+    _assert_clear(user, original_password, original_uuid)
 
 
 @pytest.mark.django_db

--- a/organisations/models.py
+++ b/organisations/models.py
@@ -1,3 +1,4 @@
+import uuid
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -125,6 +126,9 @@ class User(AbstractUser, GDPRModel, SerializableMixin):
         self.is_active = False
         self.username = f"{CLEARED_VALUE}-{self.uuid}"
         self.set_unusable_password()
+        # Change the UUID,
+        # so the deleted user won't ever be reconnected to Helsinki Profile.
+        self.uuid = uuid.uuid4()
         self.save()
 
 


### PR DESCRIPTION
PT-1758.
The GDPR API deletion should change the user UUID, so a new link to service won't select the old account again.

This fixes the old implementation before the change in https://github.com/City-of-Helsinki/palvelutarjotin/pull/362