### PR TITLE
Resolve if pEvent has any spaces left for enrolment

### DIFF
--- a/occurrences/admin.py
+++ b/occurrences/admin.py
@@ -30,12 +30,20 @@ def render_person_deleted_at(obj):
         return obj.person
 
 
-class OccurrenceInline(admin.TabularInline):
+class OccurrenceInlineThroughStudyGroups(admin.TabularInline):
     model = Occurrence.study_groups.through
     extra = 0
 
     readonly_fields = ["person_deleted_at"]
     autocomplete_fields = ["person", "occurrence"]
+
+
+class OccurrenceInline(admin.TabularInline):
+    model = Occurrence
+    extra = 0
+    autocomplete_fields = [
+        "contact_persons",
+    ]
 
 
 class EventQueueEnrolmentInline(admin.TabularInline):
@@ -92,7 +100,7 @@ class StudyGroupAdmin(admin.ModelAdmin):
         "get_person",
     )
     exclude = ("id",)
-    inlines = (OccurrenceInline, EventQueueEnrolmentInline)
+    inlines = (OccurrenceInlineThroughStudyGroups, EventQueueEnrolmentInline)
     list_filter = ["created_at", HasUnitIdStudyGroupListFilter]
     search_fields = ["unit_id", "unit_name", "person__name"]
     readonly_fields = ["person_deleted_at"]
@@ -255,6 +263,7 @@ class PalvelutarjotinEventAdmin(admin.ModelAdmin):
     )
     readonly_fields = ["contact_info_deleted_at"]
     autocomplete_fields = ["organisation", "contact_person"]
+    inlines = (OccurrenceInline,)
 
     def occurrences_count(self, obj):
         return obj.occurrences.count()

--- a/occurrences/admin.py
+++ b/occurrences/admin.py
@@ -36,6 +36,7 @@ class OccurrenceInlineThroughStudyGroups(admin.TabularInline):
 
     readonly_fields = ["person_deleted_at"]
     autocomplete_fields = ["person", "occurrence"]
+    show_change_link = True
 
 
 class OccurrenceInline(admin.TabularInline):
@@ -44,6 +45,7 @@ class OccurrenceInline(admin.TabularInline):
     autocomplete_fields = [
         "contact_persons",
     ]
+    show_change_link = True
 
 
 class EventQueueEnrolmentInline(admin.TabularInline):
@@ -52,13 +54,15 @@ class EventQueueEnrolmentInline(admin.TabularInline):
 
     readonly_fields = ["person_deleted_at"]
     autocomplete_fields = ["person", "p_event"]
+    show_change_link = True
 
 
 class EnrolmentInline(admin.TabularInline):
     model = Enrolment
     extra = 0
     exclude = ("person_deleted_at",)
-    autocomplete_fields = ["study_group", "occurrence"]
+    autocomplete_fields = ["person", "study_group", "occurrence"]
+    show_change_link = True
 
 
 class StudyGroupInline(admin.TabularInline):
@@ -163,6 +167,9 @@ class OccurrenceAdmin(admin.ModelAdmin):
         "languages",
         "cancelled",
         "seat_type",
+    ]
+    inlines = [
+        EnrolmentInline,
     ]
 
     def linked_event_id(self, obj):

--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -105,6 +105,17 @@ class PalvelutarjotinEventQueryset(TranslatableQuerySet):
             contact_info_deleted_at=now,
         )
 
+    def with_next_occurrence_start_time(self):
+        next_occurrences = Occurrence.objects.filter(
+            p_event=OuterRef("pk"), start_time__gte=timezone.now(), cancelled=False
+        ).order_by("start_time")
+
+        return self.annotate(
+            next_occurrence_start_time=Subquery(
+                next_occurrences.values("start_time")[:1]
+            )
+        )
+
 
 class PalvelutarjotinEvent(
     GDPRModel, SerializableMixin, TranslatableModel, TimestampedModel

--- a/occurrences/tests/snapshots/snap_test_api.py
+++ b/occurrences/tests/snapshots/snap_test_api.py
@@ -196,7 +196,7 @@ snapshots["test_approve_enrolment 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: barrettjason@example.org
     Click this link to cancel the enrolment:
-    https://kultus.hel.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo1NF8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://kultus.hel.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo1OF8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
 """
 ]
@@ -213,7 +213,7 @@ snapshots["test_approve_enrolment_with_custom_message 2"] = [
     Occurrence: 06.01.2020 02.00
     Person: barrettjason@example.org
     Click this link to cancel the enrolment:
-    https://kultus.hel.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo1Nl8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
+    https://kultus.hel.fi/fi/enrolments/cancel/RW5yb2xtZW50Tm9kZTo2MF8yMDIwLTAxLTA0IDAwOjAwOjAwKzAwOjAw
 
     Custom message: custom message
 """


### PR DESCRIPTION
PT-1668.

Also: 
- feat: occurrences are listed in inline component in palvelutarjotin event admin
- feat: improve the performance of admin site with auto complete fields and inline components
- refactor: move upcoming events annotation to query set. Add a new `with_next_occurrence` annotation to PalvelutarjotinEvent queryset
to do the job that was done in the upcoming events query endpoint.