### PR TITLE
chore: add DOCKER_TARGET and prod port to docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     django:
         build:
             context: .
-            target: development
+            target: ${DOCKER_TARGET:-development}
         env_file:
             - docker-compose.env.yaml
         environment:
@@ -25,6 +25,7 @@ services:
             - .:/app
         ports:
             - 8081:8081
+            - 8000:8000
         depends_on:
             - kultus-db
         container_name: kultus-backend


### PR DESCRIPTION
The production stage of the Dockerfile can now be run with `DOCKER_TARGET=production docker compose up`. The production stage is exposed in a port 8000, so it also needs to be set available in the docker-compose configuration.

The development stage is available by default `docker compose up`, but also with DOCKER_TARGET by using `DOCKER_TARGET=development docker compose up`. 

To remove existing containers, use `docker compose down`. To rebuild a container use `--build`-flag, like `DOCKER_TARGET=production docker compose up --build`.