### PR TITLE
Deactivated person should not be listed from API

### DIFF
--- a/organisations/schema.py
+++ b/organisations/schema.py
@@ -126,11 +126,13 @@ class CreateMyProfileMutation(graphene.relay.ClientIDMutation):
         person.notify_myprofile_creation()
         return CreateMyProfileMutation(my_profile=person)
 
+    @staticmethod
     def _set_organisation_proposals(organisation_proposals_data, person):
         if organisation_proposals_data and person:
             for organisation_proposal_data in organisation_proposals_data:
                 person.organisationproposal_set.create(**organisation_proposal_data)
 
+    @staticmethod
     def _set_person_organisations(organisation_ids, person):
         if organisation_ids and person:
             for org_global_id in organisation_ids:
@@ -171,6 +173,7 @@ class UpdateMyProfileMutation(graphene.relay.ClientIDMutation):
 
         return UpdateMyProfileMutation(my_profile=person)
 
+    @staticmethod
     def _set_person_organisations(organisation_ids, person):
         if organisation_ids and person:
             person.organisations.clear()

--- a/organisations/schema.py
+++ b/organisations/schema.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import transaction
+from django.db.models import Q
 from graphene import Boolean, InputObjectType, relay
 from graphene_django import DjangoConnectionField
 from graphene_django.filter import DjangoFilterConnectionField
@@ -37,6 +38,7 @@ class PersonNode(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
+        queryset = queryset.filter(Q(user__isnull=True) | Q(user__is_active=True))
         # Allow access to person related to added study group in AddStudyGroupMutation
         if info.path.as_list() == ["addStudyGroup", "studyGroup", "person"]:
             return queryset


### PR DESCRIPTION
A duplicate for https://github.com/City-of-Helsinki/palvelutarjotin/pull/370 with a shorter branch name, because it was an issue for infra.

----

PT-1804.

There are 2 kind of persons in the API: Those that acts as event
providers and are linked to some admin users, but also those that leads
a study group or makes an enrolment to the event. Both types are casted
as PersonNode, but only one of them has a user linked to it. However,
there is no case where we should currently include the deactivated user
instances, so those can always be excluded.

NOTE: After the authorization service is changed from the Tunnistamo to
the Helsinki Profile Keycloak, there will be duplicate user instances
for the admin users. Then, the clearest way to separate the old
Tunnistamo accounts from the active ones, is to mark them deactivated
and at that point, we don't want to have them listed in the event
contact person list or anywhere else.