### PR TITLE
feat(csp): install and configure CSP-plugin

### DIFF
--- a/palvelutarjotin/consts.py
+++ b/palvelutarjotin/consts.py
@@ -23,3 +23,16 @@ MISSING_MANDATORY_INFORMATION_ERROR = "MISSING_MANDATORY_INFORMATION_ERROR"
 INVALID_TOKEN_ERROR = "INVALID_TOKEN_ERROR"
 INVALID_STUDY_GROUP_UNIT_INFO_ERROR = "INVALID_STUDY_GROUP_UNIT_INFO_ERROR"
 QUEUEING_NOT_ALLOWED_ERROR = "QUEUEING_NOT_ALLOWED_ERROR"
+
+
+class CSP:
+    """The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', 'none'
+    and hash-source ('sha256-...') must be quoted! e.g.: CSP_DEFAULT_SRC = ("'self'",).
+    Without quotes they will not work as intended.
+    Ref. https://django-csp.readthedocs.io/en/stable/configuration.html.
+    """
+
+    SELF = "'self'"
+    NONE = "'none'"
+    UNSAFE_INLINE = "'unsafe-inline'"
+    UNSAFE_EVAL = "'unsafe-eval'"

--- a/palvelutarjotin/settings.py
+++ b/palvelutarjotin/settings.py
@@ -10,6 +10,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from palvelutarjotin.consts import CSP
+
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
 
@@ -183,6 +185,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "social_django",
     "corsheaders",
+    "csp",
     "graphene_django",
     "rest_framework",
     "anymail",
@@ -205,6 +208,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -232,6 +236,35 @@ TEMPLATES = [
 
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST")
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL")
+
+
+# Configure the default CSP rule for different source types
+CSP_DEFAULT_SRC = [CSP.SELF]
+
+# CSP_STYLE_SRC includes 'unsafe-inline' for inline styles added by `django-helusers`.
+CSP_STYLE_SRC = [
+    CSP.SELF,
+    CSP.UNSAFE_INLINE,
+    "cdn.jsdelivr.net",
+    "blob:",
+]
+
+CSP_SCRIPT_SRC = [
+    CSP.SELF,
+    "cdn.jsdelivr.net",  # /graphql/ endpoint
+    "blob:",
+]
+
+CSP_FONT_SRC = [
+    CSP.SELF,
+    "data:",  # /graphql/ endpoint uses "data:font/woff2"
+]
+
+CSP_IMG_SRC = [
+    CSP.SELF,
+    "blob:",
+    "data:",
+]
 
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",

--- a/palvelutarjotin/tests/test_csp.py
+++ b/palvelutarjotin/tests/test_csp.py
@@ -1,0 +1,26 @@
+import pytest
+from django.test import Client
+
+
+@pytest.fixture
+def client():
+    """Pytest fixture to provide a Django test client."""
+    return Client()
+
+
+def test_csp_header_present(client):
+    """Test that the Content-Security-Policy header is present."""
+    response = client.get("/")
+    assert "Content-Security-Policy" in response.headers
+
+
+def test_csp_header_content(client):
+    """Test that the CSP header has the expected directives."""
+    response = client.get("/")
+    csp_header = response.headers["Content-Security-Policy"]
+    # Adjust assertions based on your actual CSP configuration
+    assert "default-src 'self'" in csp_header
+    # The style-src needs 'unsafe-inline', because the django-helusers
+    # adds some inline styles when it overrides
+    # the default django admin base site template.
+    assert "style-src 'self' 'unsafe-inline'" in csp_header

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ certifi
 django-admin-list-filter-dropdown
 django-axes
 django-cors-headers
+django-csp
 django-environ
 django-filter
 django-graphql-jwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ django==4.2.20
     #   django-anymail
     #   django-axes
     #   django-cors-headers
+    #   django-csp
     #   django-filter
     #   django-graphql-jwt
     #   django-helusers
@@ -57,6 +58,8 @@ django-anymail==12.0
 django-axes==7.0.2
     # via -r requirements.in
 django-cors-headers==4.7.0
+    # via -r requirements.in
+django-csp==3.8
     # via -r requirements.in
 django-environ==0.12.0
     # via -r requirements.in


### PR DESCRIPTION
PT-1874.

Add django-csp to requirements. Configure the CSP as centralized as possible. Refactor the GraphQL-path initialization aand wrap it with unsafe-inline CSP-rule.