### PR TITLE
Fix remote address handling of manual access log audit logging

### DIFF
--- a/reports/services.py
+++ b/reports/services.py
@@ -11,8 +11,8 @@ from palvelutarjotin.exceptions import ApiBadRequestError, ObjectDoesNotExistErr
 
 def sync_enrolment_reports(
     hydrate_linkedevents_event=True,
-    sync_from: datetime = None,
-    create_from: datetime = None,
+    sync_from: Optional[datetime] = None,
+    create_from: Optional[datetime] = None,
 ):
     """
     Synchronize the enrolemnts report table with enrolments table:
@@ -34,7 +34,7 @@ def sync_enrolment_reports(
 
 
 def get_unsynced_enrollments(
-    sync_from: datetime = None,
+    sync_from: Optional[datetime] = None,
 ) -> Union[models.QuerySet, List[occurrences_models.Enrolment]]:
     """Get a list of enrolments which are updated after latest report updates."""
     sync_from = sync_from or report_models.EnrolmentReport.objects.latest_sync()
@@ -44,7 +44,7 @@ def get_unsynced_enrollments(
 
 
 def get_missing_enrollments(
-    sync_from: datetime = None,
+    sync_from: Optional[datetime] = None,
 ) -> Union[models.QuerySet, List[occurrences_models.Enrolment]]:
     """Get a list of enrolments which are missing from EnrolmentReport db-table."""
     enrolments = get_unsynced_enrollments(sync_from=sync_from)

--- a/reports/views.py
+++ b/reports/views.py
@@ -47,7 +47,9 @@ class LogAccessMixin:
     def get_queryset(self):
         queryset = super().get_queryset()
         # write access logs to auditlog
-        with set_actor(actor=self.request.user, remote_addr=get_client_ip(self.request)):
+        with set_actor(
+            actor=self.request.user, remote_addr=get_client_ip(self.request)
+        ):
             for obj in queryset:
                 accessed.send(sender=obj.__class__, instance=obj)
         return queryset
@@ -115,7 +117,10 @@ class PalvelutarjotinEventEnrolmentsMixin(ExportReportViewMixin):
     def message_max_result(self, request):
         # Inform the user if not all the data was included
         if len(self.get_queryset()) == self.max_results:
-            logger.warning("Queryset items maximum count exceeded " + "when fetching data for events enrolments report.")
+            logger.warning(
+                "Queryset items maximum count exceeded "
+                + "when fetching data for events enrolments report."
+            )
             messages.add_message(
                 request,
                 messages.WARNING,
@@ -155,21 +160,31 @@ class PalvelutarjotinEventEnrolmentsMixin(ExportReportViewMixin):
         end_date = naive_datetime_to_tz_aware(self.request.GET.get("end", None))
 
         if start_date and end_date:
-            queryset = queryset.filter(occurrence__p_event__enrolment_start__range=[start_date, end_date])
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__range=[start_date, end_date]
+            )
         elif start_date:
-            queryset = queryset.filter(occurrence__p_event__enrolment_start__gte=start_date)
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__gte=start_date
+            )
         elif end_date:
-            queryset = queryset.filter(occurrence__p_event__enrolment_start__lte=end_date)
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__lte=end_date
+            )
 
         if not event_ids and not start_date and not end_date:
             # Get this years enrolments
             today = datetime.datetime.now(tz=datetime.timezone.utc)
-            queryset = queryset.filter(occurrence__p_event__enrolment_start__year=today.year)
+            queryset = queryset.filter(
+                occurrence__p_event__enrolment_start__year=today.year
+            )
 
         # Order by occurrence start time
         # and select all related content that is needed in report.
         # In case a whole db is trying to be fetched, limit the amount of fetched items
-        return queryset.order_by("-occurrence__p_event__enrolment_start").select_related("occurrence__p_event", "study_group", "person")[
+        return queryset.order_by(
+            "-occurrence__p_event__enrolment_start"
+        ).select_related("occurrence__p_event", "study_group", "person")[
             : self.max_results
         ]
 
@@ -216,7 +231,9 @@ class OrganisationPersonsAdminView(LogAccessMixin, OrganisationPersonsMixin, Lis
 
 
 @method_decorator(staff_member_required, name="dispatch")
-class PalvelutarjotinEventEnrolmentsAdminView(PalvelutarjotinEventEnrolmentsMixin, ListView):
+class PalvelutarjotinEventEnrolmentsAdminView(
+    PalvelutarjotinEventEnrolmentsMixin, ListView
+):
     """
     The admin view which renders a table of events occurrences and enrolments.
     """
@@ -235,11 +252,17 @@ class PalvelutarjotinEventEnrolmentsAdminView(PalvelutarjotinEventEnrolmentsMixi
         context = super().get_context_data(**kwargs)
         queryset = self.get_queryset()
         context["linked_events_root"] = settings.LINKED_EVENTS_API_CONFIG["ROOT"]
-        context["total_children"] = sum(enrolment.study_group.group_size for enrolment in queryset)
-        context["total_adults"] = sum(enrolment.study_group.amount_of_adult for enrolment in queryset)
+        context["total_children"] = sum(
+            enrolment.study_group.group_size for enrolment in queryset
+        )
+        context["total_adults"] = sum(
+            enrolment.study_group.amount_of_adult for enrolment in queryset
+        )
         context["opts"] = self.model._meta
 
-        with set_actor(actor=self.request.user, remote_addr=get_client_ip(self.request)):
+        with set_actor(
+            actor=self.request.user, remote_addr=get_client_ip(self.request)
+        ):
             for enrolment in queryset:
                 accessed.send(sender=enrolment.__class__, instance=enrolment)
 
@@ -294,7 +317,9 @@ class ExportReportCsvView(ExportReportViewMixin, APIView):
         Using the semicolon (";") as a delimiter
         seems to fix UTF-8 issues with Microsoft Excel.
         """
-        writer = csv.writer(response, dialect=self.csv_dialect, delimiter=self.csv_delimiter)
+        writer = csv.writer(
+            response, dialect=self.csv_dialect, delimiter=self.csv_delimiter
+        )
 
         return (writer, response)
 
@@ -345,7 +370,9 @@ class OrganisationPersonsCsvView(OrganisationPersonsMixin, ExportReportCsvView):
     model = Organisation
 
     def get(self, request, *args, **kwargs):
-        writer, response = self._create_csv_response_writer("kultus_organisations_persons")
+        writer, response = self._create_csv_response_writer(
+            "kultus_organisations_persons"
+        )
         writer.writerow([_("Organisation"), _("Name"), _("Email"), _("Phone")])
 
         with set_actor(actor=request.user, remote_addr=get_client_ip(request)):
@@ -364,7 +391,9 @@ class OrganisationPersonsCsvView(OrganisationPersonsMixin, ExportReportCsvView):
         return response
 
 
-class PalvelutarjotinEventEnrolmentsCsvView(PalvelutarjotinEventEnrolmentsMixin, ExportReportCsvView):
+class PalvelutarjotinEventEnrolmentsCsvView(
+    PalvelutarjotinEventEnrolmentsMixin, ExportReportCsvView
+):
     """
     A csv of organisations persons.
     """
@@ -379,82 +408,112 @@ class PalvelutarjotinEventEnrolmentsCsvView(PalvelutarjotinEventEnrolmentsMixin,
     def _get_place_from_linkedevents_or_cache(place_id):
         return get_place_json_from_linkedevents(place_id)
 
-    def get(self, request, *args, **kwargs):
-        # Inform the user if not all the data was included
-        self.message_max_result(request)
-        writer, response = self._create_csv_response_writer("kultus_events_approved_enrolments")
-        writer.writerow(
-            [
-                _("Enrolment id"),
-                _("LinkedEvents id"),
-                _("LinkedEvents uri"),
-                _("Event starting date"),
-                _("Event starting time"),
-                _("Event ending date"),
-                _("Event ending time"),
-                _("Enrolment date"),
-                _("Enrolment time"),
-                _("Kindergarten / school / college"),
-                _("Group name"),
-                _("Study levels"),
-                _("Amount of children"),
-                _("Amount of adults"),
-                _("Event location"),
-                _("Extra needs"),
-                _("Contact mail"),
-                _("Contact phone"),
-            ]
+    def _write_csv_events_approved_enrolments_table(self, request):
+        writer, response = self._create_csv_response_writer(
+            "kultus_events_approved_enrolments"
         )
+
+        def _write_csv_header_row():
+            writer.writerow(
+                [
+                    _("Enrolment id"),
+                    _("LinkedEvents id"),
+                    _("LinkedEvents uri"),
+                    _("Event starting date"),
+                    _("Event starting time"),
+                    _("Event ending date"),
+                    _("Event ending time"),
+                    _("Enrolment date"),
+                    _("Enrolment time"),
+                    _("Kindergarten / school / college"),
+                    _("Group name"),
+                    _("Study levels"),
+                    _("Amount of children"),
+                    _("Amount of adults"),
+                    _("Event location"),
+                    _("Extra needs"),
+                    _("Contact mail"),
+                    _("Contact phone"),
+                ]
+            )
+
+        def _write_csv_data_row(enrolment):
+            start_datetime = timezone.localtime(enrolment.occurrence.start_time)
+            end_datetime = timezone.localtime(enrolment.occurrence.end_time)
+            enrolment_datetime = timezone.localtime(enrolment.enrolment_time)
+
+            place = (
+                self._get_place_from_linkedevents_or_cache(
+                    enrolment.occurrence.place_id
+                )
+                if enrolment.occurrence.place_id
+                else None
+            )
+
+            if enrolment.person:
+                person_email_address = enrolment.person.email_address
+                person_phone_number = enrolment.person.phone_number
+            elif enrolment.person_deleted_at:
+                person_email_address = person_phone_number = (
+                    f"{_('Deleted')} "
+                    + f"{enrolment.person_deleted_at.strftime(self.DATE_FORMAT)}"
+                )
+            else:
+                person_email_address = person_phone_number = ""
+
+            writer.writerow(
+                [
+                    enrolment.id,
+                    enrolment.occurrence.p_event.linked_event_id,
+                    "{linked_events_root}event/{linked_event_id}".format(
+                        linked_events_root=settings.LINKED_EVENTS_API_CONFIG["ROOT"],
+                        linked_event_id=enrolment.occurrence.p_event.linked_event_id,
+                    ),
+                    start_datetime.strftime(self.DATE_FORMAT),
+                    start_datetime.strftime(self.TIME_FORMAT),
+                    end_datetime.strftime(self.DATE_FORMAT),
+                    end_datetime.strftime(self.TIME_FORMAT),
+                    enrolment_datetime.strftime(self.DATE_FORMAT),
+                    enrolment_datetime.strftime(self.TIME_FORMAT),
+                    enrolment.study_group.unit_name,
+                    enrolment.study_group.group_name,
+                    ", ".join(
+                        [
+                            study_level.label
+                            for study_level in enrolment.study_group.study_levels.all()
+                        ]
+                    ),
+                    enrolment.study_group.group_size,
+                    enrolment.study_group.amount_of_adult,
+                    (
+                        place["name"].get("fi")
+                        or place["name"].get("sv")
+                        or place["name"].get("en")
+                    )
+                    if place
+                    else "",
+                    enrolment.study_group.extra_needs,
+                    person_email_address,
+                    person_phone_number,
+                ]
+            )
 
         # write access logs to auditlog
         with set_actor(
             actor=request.user,
             remote_addr=get_client_ip(request),
         ):
+            _write_csv_header_row()
             for enrolment in self.get_queryset():
                 accessed.send(sender=enrolment.__class__, instance=enrolment)
-                start_datetime = timezone.localtime(enrolment.occurrence.start_time)
-                end_datetime = timezone.localtime(enrolment.occurrence.end_time)
-                enrolment_datetime = timezone.localtime(enrolment.enrolment_time)
+                _write_csv_data_row(enrolment)
 
-                place = self._get_place_from_linkedevents_or_cache(enrolment.occurrence.place_id) if enrolment.occurrence.place_id else None
-
-                if enrolment.person:
-                    person_email_address = enrolment.person.email_address
-                    person_phone_number = enrolment.person.phone_number
-                elif enrolment.person_deleted_at:
-                    person_email_address = person_phone_number = (
-                        f"{_('Deleted')} " + f"{enrolment.person_deleted_at.strftime(self.DATE_FORMAT)}"
-                    )
-                else:
-                    person_email_address = person_phone_number = ""
-
-                writer.writerow(
-                    [
-                        enrolment.id,
-                        enrolment.occurrence.p_event.linked_event_id,
-                        "{linked_events_root}event/{linked_event_id}".format(
-                            linked_events_root=settings.LINKED_EVENTS_API_CONFIG["ROOT"],
-                            linked_event_id=enrolment.occurrence.p_event.linked_event_id,
-                        ),
-                        start_datetime.strftime(self.DATE_FORMAT),
-                        start_datetime.strftime(self.TIME_FORMAT),
-                        end_datetime.strftime(self.DATE_FORMAT),
-                        end_datetime.strftime(self.TIME_FORMAT),
-                        enrolment_datetime.strftime(self.DATE_FORMAT),
-                        enrolment_datetime.strftime(self.TIME_FORMAT),
-                        enrolment.study_group.unit_name,
-                        enrolment.study_group.group_name,
-                        ", ".join([study_level.label for study_level in enrolment.study_group.study_levels.all()]),
-                        enrolment.study_group.group_size,
-                        enrolment.study_group.amount_of_adult,
-                        (place["name"].get("fi") or place["name"].get("sv") or place["name"].get("en")) if place else "",
-                        enrolment.study_group.extra_needs,
-                        person_email_address,
-                        person_phone_number,
-                    ]
-                )
         return response
+
+    def get(self, request, *args, **kwargs):
+        # Inform the user if not all the data was included
+        self.message_max_result(request)
+        return self._write_csv_events_approved_enrolments_table(request)
 
 
 class EnrolmentReportCsvView(ExportReportCsvView):
@@ -464,7 +523,9 @@ class EnrolmentReportCsvView(ExportReportCsvView):
 @staff_member_required
 @require_http_methods(["POST"])
 def sync_enrolment_reports_view(request):
-    create_from = Enrolment.objects.aggregate(Min("enrolment_time"))["enrolment_time__min"]
+    create_from = Enrolment.objects.aggregate(Min("enrolment_time"))[
+        "enrolment_time__min"
+    ]
     sync_enrolment_reports(hydrate_linkedevents_event=True, create_from=create_from)
     messages.add_message(request, messages.SUCCESS, _("Enrolment reports synced!"))
     return HttpResponseRedirect(reverse("admin:reports_enrolmentreport_changelist"))
@@ -545,7 +606,9 @@ class EnrolmentReportListView(LogListAccessMixin, generics.ListAPIView):
 
         # Parse non-datetime filter parameters
         filter_params = {
-            k: self.request.query_params.get(k) for k in self.allowed_non_datetime_filter_keys if self.request.query_params.get(k)
+            k: self.request.query_params.get(k)
+            for k in self.allowed_non_datetime_filter_keys
+            if self.request.query_params.get(k)
         }
         # Parse datetime filter parameters
         filter_params.update(


### PR DESCRIPTION
PT-1909.

Remove port from the returned value of the `get_client_ip` -function.

Other miscallenous changes:
- fix a possible null pointer exception
- fix varaible typing
- refactor the writing of events approved enrolments CSV
