### PR TITLE
chore: add environment variables for Keycloak auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ GDPR_API_QUERY_SCOPE=gdprquery
 GDPR_API_DELETE_SCOPE=gdprdelete
 TOKEN_AUTH_API_AUTHORIZATION_FIELD=authorization.permissions.scopes
 HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=True
+HELUSERS_PASSWORD_LOGIN_DISABLED=False
+# Django Admin OIDC endpoint
+SOCIAL_AUTH_TUNNISTAMO_KEY=kultus-django-admin-dev
+SOCIAL_AUTH_TUNNISTAMO_SECRET=
 # Values in DATABASE_* and POSTGRES_* variables must match!
 # DATABASE_URL is used by Django
 # DATABASE_HOST is used by docker-entrypoint.sh


### PR DESCRIPTION
PT-1830.

OIDC was already configured with django-helusers, but the Django Admin Keycloak authentication part was missing. Instructions for that could be found from django-helusers readme documentation:
https://github.com/City-of-Helsinki/django-helusers?tab=readme-ov-file#django-session-login.

Pipeline changes are done in Azure dev PR:
https://dev.azure.com/City-of-Helsinki/kultus/_git/kultus-pipelines/pullrequest/11506.