### PR TITLE
fix: event contact person should be publicly available

### DIFF
--- a/occurrences/schema.py
+++ b/occurrences/schema.py
@@ -51,7 +51,7 @@ from occurrences.schema_services import (
 )
 from organisations.decorators import event_staff_member_required
 from organisations.models import Organisation
-from organisations.schema import PersonNodeInput
+from organisations.schema import PersonNodeInput, PublicPersonNode
 from palvelutarjotin.exceptions import (
     AlreadyJoinedEventError,
     ApiUsageError,
@@ -193,6 +193,7 @@ class PalvelutarjotinEventNode(DjangoObjectType):
         "ACCEPT-LANGUAGE header "
     )
     translations = graphene.List(PalvelutarjotinEventTranslationType)
+    contact_person = graphene.Field(PublicPersonNode)
 
     class Meta:
         model = PalvelutarjotinEvent

--- a/organisations/tests/schema.py
+++ b/organisations/tests/schema.py
@@ -1,0 +1,15 @@
+from graphene import ObjectType, Schema
+from graphene_django import DjangoConnectionField
+
+from organisations.models import Person
+from organisations.schema import PublicPersonNode
+
+
+class TestQuery(ObjectType):
+    all_public_person_nodes = DjangoConnectionField(PublicPersonNode)
+
+    def resolve_all_public_person_nodes(root, info):
+        return PublicPersonNode.get_queryset(Person.objects.all(), info)
+
+
+test_schema = Schema(query=TestQuery)


### PR DESCRIPTION
PT-1898.

Fix an issue showing the event contact person information.

Add a `PublicPersonNode` on side with `PersonNode`. In `PublicPersonNode`, the access is not restricted only for staff. It's publicly readable, since it's reference to public event information.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/4db293eb-cc20-49d0-8952-dfc25baf30bf" />
