### PR TITLE
fix: CSV endpoints incorrectly responding with 403

### DIFF
--- a/reports/tests/test_views.py
+++ b/reports/tests/test_views.py
@@ -396,8 +396,8 @@ class PersonsCsvViewTest(TestCase):
         PERSONS_BATCH_COUNT = 2
         person_1, person_2 = PersonFactory.create_batch(PERSONS_BATCH_COUNT)
 
-        admin_user = UserFactory(is_staff=True)
-        user = UserFactory(is_staff=False)
+        admin_user = UserFactory(is_event_staff=True)
+        user = UserFactory(is_event_staff=False)
 
         user_api_client = APIClient()
         user_api_client.force_authenticate(user=user)
@@ -427,7 +427,7 @@ class PersonsCsvViewTest(TestCase):
         self,
     ):
         PERSON_BATCH_COUNT = 2
-        admin_user = UserFactory(is_staff=True)
+        admin_user = UserFactory(is_event_staff=True)
         PersonFactory.create_batch(
             PERSON_BATCH_COUNT,
         )
@@ -458,8 +458,8 @@ class OrganisationPersonsCsvViewTest(TestCase):
         person_1 = PersonFactory.create(organisations=[org1])
         person_2 = PersonFactory.create(organisations=[org2])
 
-        admin_user = UserFactory(is_staff=True)
-        user = UserFactory(is_staff=False)
+        admin_user = UserFactory(is_event_staff=True)
+        user = UserFactory(is_event_staff=False)
 
         user_api_client = APIClient()
         user_api_client.force_authenticate(user=user)
@@ -536,8 +536,8 @@ class PalvelutarjotinEventEnrolmentsTest(TestCase):
                 study_group=StudyGroupFactory(group_size=2, amount_of_adult=1),
             )
 
-        admin_user = UserFactory(is_staff=True)
-        user = UserFactory(is_staff=False)
+        admin_user = UserFactory(is_event_staff=True)
+        user = UserFactory(is_event_staff=False)
 
         user_api_client = APIClient()
         user_api_client.force_authenticate(user=user)

--- a/reports/views/csv_api.py
+++ b/reports/views/csv_api.py
@@ -12,7 +12,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
 from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import BasePermission
 
 from common.utils import (
     get_client_ip,
@@ -33,6 +33,15 @@ from reports.views.mixins import (
 logger = logging.getLogger(__name__)
 
 
+class IsEventAdminUser(BasePermission):
+    """
+    Allows access only to event admin users.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_event_staff)
+
+
 class ExportReportCsvView(ExportReportViewMixin, generics.GenericAPIView):
     """
     A generic API view that provides functionality to export model data as a CSV file.
@@ -49,7 +58,7 @@ class ExportReportCsvView(ExportReportViewMixin, generics.GenericAPIView):
     model = None
     serializer_class = None
     authentication_classes = [KultusApiTokenAuthentication, SessionAuthentication]
-    permission_classes = [IsAdminUser]
+    permission_classes = [IsEventAdminUser]
     csv_dialect = csv.excel
     csv_delimiter = ";"
 


### PR DESCRIPTION
The logic for authenticating admin (staff) users was refactored previously. Along this users were migrated from using Django's is_staff to using a custom is_event_staff.

The ExportReportCsvView was not updated to reflect this change, which resulted in admin users receiving 403 errors when attempting to download CSV files.

refs: PT-1812, PT-1942