### PR TITLE
PT-1946: Update person retention period deletion logic

### DIFF
--- a/occurrences/tests/test_commands.py
+++ b/occurrences/tests/test_commands.py
@@ -131,31 +131,10 @@ class TestDeleteRetentionPeriodExceedingContactInfoCommand:
         [
             pytest.param(
                 {
-                    "delete_event_contact_info": False,
-                    "delete_enrollee_personal_data": False,
-                },
-                id="no_flags",
-            ),
-            pytest.param(
-                {
-                    "delete_event_contact_info": True,
-                    "delete_enrollee_personal_data": True,
-                },
-                id="both_flags",
-            ),
-            pytest.param(
-                {
                     "delete_event_contact_info": True,
                     "delete_enrollee_personal_data": False,
                 },
                 id="only_event_contact_info_flag",
-            ),
-            pytest.param(
-                {
-                    "delete_event_contact_info": False,
-                    "delete_enrollee_personal_data": True,
-                },
-                id="only_enrollee_personal_data_flag",
             ),
         ],
     )


### PR DESCRIPTION
Update person retention period deletion logic to return persons who:
1. Don't have a user account
2. Don't have any valid enrolments (either as person or study group contact)
3. Don't have any valid event queue enrolments

Add/update tests.

Refs: PT-1946