### PR TITLE
feat: add password login allowlist

### DIFF
--- a/palvelutarjotin/settings.py
+++ b/palvelutarjotin/settings.py
@@ -95,6 +95,7 @@ env = environ.Env(
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
     HELUSERS_USER_MIGRATE_ENABLED=(bool, False),
     HELUSERS_PASSWORD_LOGIN_DISABLED=(bool, True),
+    HELUSERS_PASSWORD_LOGIN_ALLOWLIST=(list, []),
     TOKEN_AUTH_BROWSER_TEST_JWT_256BIT_SIGN_SECRET=(str, ""),
     TOKEN_AUTH_BROWSER_TEST_JWT_ISSUER=(list, []),
     TOKEN_AUTH_BROWSER_TEST_ENABLED=(bool, False),
@@ -571,6 +572,7 @@ HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = env.bool(
 )
 # A boolean that disables/enables Django admin password login
 HELUSERS_PASSWORD_LOGIN_DISABLED = env.bool("HELUSERS_PASSWORD_LOGIN_DISABLED")
+HELUSERS_PASSWORD_LOGIN_ALLOWLIST = env("HELUSERS_PASSWORD_LOGIN_ALLOWLIST")
 
 # Load auditlog settings
 from palvelutarjotin.auditlog_settings import *  # noqa: E402, F403

--- a/requirements.txt
+++ b/requirements.txt
@@ -387,9 +387,9 @@ django-helsinki-health-endpoints==1.0.0 \
     --hash=sha256:75670113e99bfd1fc23e317a3a22cff563140f495655c2a5f6ab219389dafd52 \
     --hash=sha256:eebf1baa6917d7b0e11123aec191df773883102ec1653025a86d7037dba389e2
     # via -r requirements.in
-django-helusers==1.0.0 \
-    --hash=sha256:0e33e238347a4088927675574a7dad179ee1f9d9e958daecfa4862ad6f63f79c \
-    --hash=sha256:c18ff8ff0ff8fb72c2b802e005c680d4d477273b705a5c524aaff31c665d8e25
+django-helusers==1.1.0 \
+    --hash=sha256:5d6c4d0db11db633a031cfdcef6e754fb26c167d3e179d77882c2edecca60830 \
+    --hash=sha256:73ef1c9f3050cbb3a4f3a35264f26807f60a00b66eef31d8b07cd1ffd61de965
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api


### PR DESCRIPTION
Bump django-helusers to allow defined usernames to log in using the password login.

Refs: PT-1987