### PR TITLE
fix: normalize linkedevents API errors

### DIFF
--- a/graphene_linked_events/schema.py
+++ b/graphene_linked_events/schema.py
@@ -39,6 +39,7 @@ from graphene_linked_events.utils import (
     get_keyword_set_by_id,
     json2obj,
     json_object_hook,
+    list_linked_events_data,
     retrieve_linked_events_data,
 )
 from occurrences.event_api_services import prepare_published_event_data
@@ -621,24 +622,18 @@ class Query:
 
     @staticmethod
     def resolve_places(parent, info, **kwargs):
-        response = api_client.list("place", filter_list=kwargs)
-        response.raise_for_status()
-        return json2obj(format_response(response))
+        return list_linked_events_data("place", params=kwargs)
 
     @staticmethod
     def resolve_keyword(parent, info, **kwargs):
         keyword_id = kwargs["id"]
         if not keyword_id:
             return None
-        response = api_client.retrieve("keyword", keyword_id)
-        response.raise_for_status()
-        return json2obj(format_response(response))
+        return retrieve_linked_events_data("keyword", keyword_id)
 
     @staticmethod
     def resolve_keywords(parent, info, **kwargs):
-        response = api_client.list("keyword", filter_list=kwargs)
-        response.raise_for_status()
-        return json2obj(format_response(response))
+        return list_linked_events_data("keyword", params=kwargs)
 
     @staticmethod
     def resolve_popular_kultus_keywords(parent, info, **kwargs):

--- a/graphene_linked_events/tests/test_api.py
+++ b/graphene_linked_events/tests/test_api.py
@@ -10,7 +10,7 @@ import responses
 from django.utils import timezone
 from graphene.utils.str_converters import to_snake_case
 from graphql_relay import to_global_id
-from requests.models import HTTPError
+from requests.exceptions import HTTPError, Timeout
 
 import graphene_linked_events
 from common.tests.utils import (
@@ -31,7 +31,10 @@ from graphene_linked_events.tests.mock_data import (
     UPDATE_EVENT_DATA,
 )
 from graphene_linked_events.tests.utils import MockResponse
-from graphene_linked_events.utils import retrieve_linked_events_data
+from graphene_linked_events.utils import (
+    list_linked_events_data,
+    retrieve_linked_events_data,
+)
 from occurrences.event_api_services import update_event_to_linkedevents_api
 from occurrences.factories import (
     EnrolmentFactory,
@@ -39,8 +42,12 @@ from occurrences.factories import (
     PalvelutarjotinEventFactory,
 )
 from occurrences.models import Occurrence, PalvelutarjotinEvent
-from palvelutarjotin.consts import API_USAGE_ERROR, DATA_VALIDATION_ERROR
-from palvelutarjotin.exceptions import ApiBadRequestError, ObjectDoesNotExistError
+from palvelutarjotin.consts import API_USAGE_ERROR, DATA_VALIDATION_ERROR, GENERAL_ERROR
+from palvelutarjotin.exceptions import (
+    ApiBadRequestError,
+    LinkedEventsApiError,
+    ObjectDoesNotExistError,
+)
 
 
 def __eq_dt_with_tz(dt1: Optional[datetime], dt2: Optional[datetime]) -> bool:
@@ -2283,6 +2290,7 @@ def test_get_popular_kultus_keywords_partial_results(api_client, monkeypatch, se
         (400, ApiBadRequestError),
         (404, ObjectDoesNotExistError),
         (410, ObjectDoesNotExistError),
+        (500, LinkedEventsApiError),
     ],
 )
 def test_linkedevents_api_retrieve_errors(status_code, error_cls):
@@ -2293,6 +2301,58 @@ def test_linkedevents_api_retrieve_errors(status_code, error_cls):
     ):
         with pytest.raises(error_cls):
             retrieve_linked_events_data("event", 1)
+
+
+def test_linkedevents_api_list_http_error():
+    with patch.object(
+        LinkedEventsApiClient,
+        "list",
+        return_value=mocked_json_response(data=None, status_code=504),
+    ):
+        with pytest.raises(LinkedEventsApiError):
+            list_linked_events_data("place")
+
+
+def test_linkedevents_api_request_error():
+    with patch.object(
+        LinkedEventsApiClient,
+        "retrieve",
+        side_effect=Timeout("Connection to api.hel.fi timed out"),
+    ):
+        with pytest.raises(LinkedEventsApiError):
+            retrieve_linked_events_data("event", 1)
+
+
+def test_linkedevents_api_invalid_json():
+    response = MockResponse(json_data={}, status_code=200)
+    response.text = "<html>Gateway Timeout</html>"
+
+    with patch.object(LinkedEventsApiClient, "list", return_value=response):
+        with pytest.raises(LinkedEventsApiError):
+            list_linked_events_data("place")
+
+
+@pytest.mark.parametrize(
+    ("query", "field", "api_method"),
+    [
+        (GET_PLACES_QUERY, "places", "list"),
+        (GET_KEYWORDS_QUERY, "keywords", "list"),
+        (GET_KEYWORD_QUERY, "keyword", "retrieve"),
+    ],
+)
+def test_linkedevents_resolver_returns_controlled_error(
+    api_client, monkeypatch, query, field, api_method
+):
+    def raise_timeout(*args, **kwargs):
+        raise Timeout("Connection to api.hel.fi timed out")
+
+    monkeypatch.setattr(LinkedEventsApiClient, api_method, raise_timeout)
+
+    executed = api_client.execute(query)
+
+    assert executed["data"][field] is None
+    assert executed["errors"][0]["extensions"]["code"] == GENERAL_ERROR
+    assert "NameError" not in executed["errors"][0]["message"]
 
 
 @pytest.mark.parametrize(

--- a/graphene_linked_events/utils.py
+++ b/graphene_linked_events/utils.py
@@ -1,17 +1,25 @@
 # https://stackoverflow.com/questions/6578986/how-to-convert-json-data
 # -into-a-python-object/15882054#15882054
 import json
+import logging
 from collections import namedtuple
 from typing import List
 
+import requests
 from django.conf import settings
 from geopy import Point
 from geopy import distance as geopy_distance
 
 from graphene_linked_events.rest_client import LinkedEventsApiClient
-from palvelutarjotin.exceptions import ApiBadRequestError, ObjectDoesNotExistError
+from palvelutarjotin.exceptions import (
+    ApiBadRequestError,
+    LinkedEventsApiError,
+    ObjectDoesNotExistError,
+)
 
 api_client = LinkedEventsApiClient(config=settings.LINKED_EVENTS_API_CONFIG)
+
+logger = logging.getLogger(__name__)
 
 
 def format_response(response):
@@ -44,28 +52,71 @@ def format_request(request):
     return json.dumps(request).replace("internal_", "@")
 
 
+def _fetch_linked_events_data(
+    request, resource, resource_id=None, preserve_status_errors=False
+):
+    resource_path = f"{resource}/{resource_id}" if resource_id is not None else resource
+
+    try:
+        response = request()
+
+        if response.status_code == 400:
+            raise ApiBadRequestError("Could not establish a connection to the API.")
+
+        if preserve_status_errors:
+            if response.status_code == 404:
+                raise ObjectDoesNotExistError("Could not find the event from the API.")
+
+            if response.status_code == 410:
+                raise ObjectDoesNotExistError(
+                    "The resource is no longer available in the API (gone)."
+                )
+
+        response.raise_for_status()
+        return json2obj(format_response(response))
+
+    except requests.exceptions.RequestException as e:
+        logger.warning(
+            "Request error fetching '%s' from LinkedEvents API: %s",
+            resource_path,
+            e,
+        )
+        raise LinkedEventsApiError(
+            "Failed to fetch data from LinkedEvents API. "
+            "The service may be temporarily unavailable."
+        ) from e
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "Invalid JSON response for '%s' from LinkedEvents API: %s",
+            resource_path,
+            e,
+        )
+        raise LinkedEventsApiError(
+            "Received an invalid response from LinkedEvents API. "
+            "The service may be experiencing issues."
+        ) from e
+
+
 def retrieve_linked_events_data(
     resource, resource_id, params=None, is_event_staff=False
 ):
-    response = api_client.retrieve(
-        resource, resource_id, params=params, is_event_staff=is_event_staff
+    return _fetch_linked_events_data(
+        lambda: api_client.retrieve(
+            resource, resource_id, params=params, is_event_staff=is_event_staff
+        ),
+        resource,
+        resource_id=resource_id,
+        preserve_status_errors=True,
     )
 
-    if response.status_code == 400:
-        raise ApiBadRequestError("Could not establish a connection to the API.")
 
-    if response.status_code == 404:
-        raise ObjectDoesNotExistError("Could not find the event from the API.")
-
-    if response.status_code == 410:
-        raise ObjectDoesNotExistError(
-            "The resource is no longer available in the API (gone)."
-        )
-
-    # Raise any other errors
-    response.raise_for_status()
-
-    return json2obj(format_response(response))
+def list_linked_events_data(resource, params=None, is_event_staff=False):
+    return _fetch_linked_events_data(
+        lambda: api_client.list(
+            resource, filter_list=params, is_event_staff=is_event_staff
+        ),
+        resource,
+    )
 
 
 def get_keyword_set_by_id(keyword_set_id):

--- a/occurrences/models.py
+++ b/occurrences/models.py
@@ -43,6 +43,7 @@ from organisations.models import Person, User
 from palvelutarjotin.exceptions import (
     ApiUsageError,
     EnrolmentNotEnoughCapacityError,
+    LinkedEventsApiError,
     ObjectDoesNotExistError,
 )
 from verification_token.models import VerificationToken
@@ -238,7 +239,7 @@ class PalvelutarjotinEvent(
             )
         except ObjectDoesNotExistError:
             return None
-        except HTTPError as e:
+        except (HTTPError, LinkedEventsApiError) as e:
             logger.warning(
                 "Could not retrieve the linked events data "
                 f"with linked_event_id {self.linked_event_id}. Error: {e}"

--- a/occurrences/tests/test_models.py
+++ b/occurrences/tests/test_models.py
@@ -29,7 +29,10 @@ from occurrences.models import (
 )
 from organisations.factories import PersonFactory, UserFactory
 from organisations.models import Organisation, Person
-from palvelutarjotin.exceptions import EnrolmentNotEnoughCapacityError
+from palvelutarjotin.exceptions import (
+    EnrolmentNotEnoughCapacityError,
+    LinkedEventsApiError,
+)
 from verification_token.models import VerificationToken
 
 User = get_user_model()
@@ -46,6 +49,18 @@ def test_palvelutarjotin_event(mock_get_event_data):
     assert PalvelutarjotinEvent.objects.count() == 1
     assert Organisation.objects.count() == 1
     assert Person.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_palvelutarjotin_event_handles_linkedevents_error(mock_get_event_data):
+    p_event = PalvelutarjotinEventFactory()
+
+    with patch(
+        "occurrences.models.retrieve_linked_events_data",
+        side_effect=LinkedEventsApiError("LinkedEvents API unavailable"),
+    ):
+        assert p_event.get_event_data() is None
+        assert p_event.is_published() is False
 
 
 @pytest.mark.django_db

--- a/palvelutarjotin/exceptions.py
+++ b/palvelutarjotin/exceptions.py
@@ -22,7 +22,11 @@ class ObjectDoesNotExistError(PalvelutarjotinGraphQLError):
 
 
 class ApiBadRequestError(PalvelutarjotinGraphQLError):
-    """Bad request, e.g. JsonDecodeError"""
+    """Bad request from an API."""
+
+
+class LinkedEventsApiError(PalvelutarjotinGraphQLError):
+    """LinkedEvents API is unavailable or returned invalid data."""
 
 
 class QueryTooDeepError(PalvelutarjotinGraphQLError):


### PR DESCRIPTION
## Summary

Centralize LinkedEvents request and response handling so transport failures, unexpected HTTP errors, and malformed JSON become controlled GraphQL errors. Simplify the affected places and keyword resolvers and add focused regression coverage while preserving successful response shapes and existing retrieve status mappings.

Refs: PT-1991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving linked event lists through GraphQL place and keyword queries.
  * Improved consistency in linked event data retrieval and response formatting.

* **Bug Fixes**
  * Improved handling of request timeouts, HTTP failures, and invalid responses.
  * GraphQL queries now return clearer error responses without exposing internal error details.
  * Preserved specific handling for common linked event API status errors.
  * Events with unavailable linked event data are now handled safely and remain unpublished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->